### PR TITLE
Mythic Keystones

### DIFF
--- a/core/Utility.lua
+++ b/core/Utility.lua
@@ -160,7 +160,7 @@ end
 
 local function __GetDistinctItemID(link)
 	if not link or not addon.IsValidItemLink(link) then return end
-	if strmatch(link, "battlepet:") then
+	if strmatch(link, "battlepet:") or strmatch(link, "keystone:") then
 		return link
 	else
 		local itemString, id, enchant, gem1, gem2, gem3, gem4, suffix, reforge = strmatch(link, '(item:(%-?%d+):(%-?%d+):(%-?%d+):(%-?%d+):(%-?%d+):(%-?%d+):(%-?%d+):%-?%d+:%-?%d+:(%-?%d+))')
@@ -266,7 +266,7 @@ end
 --------------------------------------------------------------------------------
 
 function addon.GetItemFamily(item)
-	if (type(item) == "string" and strmatch(item, "battlepet:")) or select(9, GetItemInfo(item)) == "INVTYPE_BAG" then
+	if (type(item) == "string" and (strmatch(item, "battlepet:") or strmatch(item, "keystone:"))) or select(9, GetItemInfo(item)) == "INVTYPE_BAG" then 
 		return 0
 	else
 		return GetItemFamily(item)

--- a/core/Utility.lua
+++ b/core/Utility.lua
@@ -266,7 +266,7 @@ end
 --------------------------------------------------------------------------------
 
 function addon.GetItemFamily(item)
-	if (type(item) == "string" and (strmatch(item, "battlepet:") or strmatch(item, "keystone:"))) or select(9, GetItemInfo(item)) == "INVTYPE_BAG" then 
+	if (type(item) == "string" and (strmatch(item, "battlepet:") or strmatch(item, "keystone:"))) or select(9, GetItemInfo(item)) == "INVTYPE_BAG" then
 		return 0
 	else
 		return GetItemFamily(item)

--- a/core/Utility.lua
+++ b/core/Utility.lua
@@ -149,7 +149,7 @@ end
 --------------------------------------------------------------------------------
 
 function addon.IsValidItemLink(link)
-	if type(link) == "string" and (strmatch(link, "battlepet:") or (strmatch(link, 'item:[-:%d]+') and not strmatch(link, 'item:%d+:0:0:0:0:0:0:0:0:0'))) then
+	if type(link) == "string" and (strmatch(link, "battlepet:") or strmatch(link, "keystone:") or (strmatch(link, 'item:[-:%d]+') and not strmatch(link, 'item:%d+:0:0:0:0:0:0:0:0:0'))) then
 		return true
 	end
 end

--- a/modules/FilterOverride.lua
+++ b/modules/FilterOverride.lua
@@ -168,6 +168,8 @@ function mod:GetOptions()
 	local function GetItemId(str)
 		if type(str) == "string" and strmatch(str, "battlepet:") then
 			return 82800 -- Official item (Pet Cage)
+		elseif type(str) == "string" and strmatch(str, "keystone:") then
+			return 138019 -- Official item (Mythic Keystone)
 		elseif str then
 			local link = select(2, GetItemInfo(str))
 			return link and tonumber(link:match("item:(%d+)"))

--- a/widgets/ContainerFrame.lua
+++ b/widgets/ContainerFrame.lua
@@ -616,6 +616,9 @@ function containerProto:UpdateContent(bag)
 			local name, count, quality, iLevel, reqLevel, class, subclass, maxStack, equipSlot, texture, vendorPrice
 			if link then
 				name, _, quality, iLevel, reqLevel, class, subclass, maxStack, equipSlot, texture, vendorPrice = GetItemInfo(link)
+				if not name then
+					name, _, quality, iLevel, reqLevel, class, subclass, maxStack, equipSlot, texture, vendorPrice = GetItemInfo(itemId)
+				end
 				count = select(2, GetContainerItemInfo(bag, slot)) or 0
 			else
 				link, count = false, 0


### PR DESCRIPTION
fix for some issues in https://github.com/AdiAddons/AdiBags/issues/169
ItemLinks for Mythic Keystones no longer use the standard itemString and use a new keystone string instead.

function containerProto:UpdateContent(bag) in AdiBags\widgets\ContainerFrame.lua uses GetItemInfo(link) to populate the slotData table.  GetItemInfo with a keystone as the itemlink returns no values so slotData is not properly populated.