### PR TITLE
ItemLevel Changes

### DIFF
--- a/modules/ItemLevel.lua
+++ b/modules/ItemLevel.lua
@@ -1,3 +1,10 @@
+-- @Author: Brian Thurlow
+-- @Date:   06/19/2017 02:19:51 PM
+-- @Last modified by:   Brian Thurlow
+-- @Last modified time: 06/20/2017 02:16:24 PM
+
+
+
 --[[
 AdiBags - Adirelle's bag addon.
 Copyright 2013-2014 Adirelle (adirelle@gmail.com)
@@ -64,6 +71,8 @@ function mod:OnInitialize()
 			minLevel = 1,
 			ignoreJunk = true,
 			ignoreHeirloom = true,
+			textPos = 'TOPLEFT',
+			upgIconPos = 'TOPLEFT',
 		},
 	})
 	if self.db.profile.colored == true then
@@ -97,6 +106,10 @@ end
 function mod:OnDisable()
 	for _, text in pairs(texts) do
 		text:Hide()
+		if _.UpgradeIcon then
+			_.UpgradeIcon:ClearAllPoints()
+			_.UpgradeIcon:SetPoint("TOPLEFT",_,"TOPLEFT")
+		end
 	end
 end
 
@@ -137,6 +150,10 @@ function mod:UpdateButton(event, button)
 			end
 			text:SetText(level)
 			text:SetTextColor(colorSchemes[settings.colorScheme](level, quality, reqLevel, (loc ~= "")))
+			--Update Position Based on settings
+			text:ClearAllPoints()
+			text:SetPoint(settings.textPos, button, settings.textPos)
+			--------------------------------------
 			return text:Show()
 		end
 	end
@@ -165,7 +182,7 @@ function mod:GetOptions()
 		},
 		colorScheme = {
 			name = L['Color scheme'],
-			desc = L['Which color scheme should be used to display the item level ?'],
+			desc = L['Which color scheme should be used to display the item level?'],
 			type = 'select',
 			hidden = SyLevelBypass,
 			values = {
@@ -196,6 +213,40 @@ function mod:GetOptions()
 			desc = L['Do not show level of heirloom items.'],
 			type = 'toggle',
 			order = 50,
+		},
+		textPos = {
+			name = L['Text Position'],
+			desc = L['Where to show the item level?'],
+			type = 'select',
+			values = {
+				TOPLEFT     = L['Top Left'],
+				TOPRIGHT = L['Top Right'],
+				TOP    = L['Top'],
+				LEFT    = L['Left'],
+				RIGHT    = L['Right'],
+				CENTER    = L['Center'],
+				BOTTOMLEFT    = L['Bottom Left'],
+				BOTTOMRIGHT    = L['Bottom Right'],
+				BOTTOM    = L['Bottom'],
+			},
+			order = 60,
+		},
+		upgIconPos = {
+			name = L['Upgrade Icon Position'],
+			desc = L['Where to show the upgrade icon?'],
+			type = 'select',
+			values = {
+				TOPLEFT     = L['Top Left'],
+				TOPRIGHT = L['Top Right'],
+				TOP    = L['Top'],
+				LEFT    = L['Left'],
+				RIGHT    = L['Right'],
+				CENTER    = L['Center'],
+				BOTTOMLEFT    = L['Bottom Left'],
+				BOTTOMRIGHT    = L['Bottom Right'],
+				BOTTOM    = L['Bottom'],
+			},
+			order = 70,
 		},
 	}, addon:GetOptionHandler(self)
 end

--- a/widgets/ItemButton.lua
+++ b/widgets/ItemButton.lua
@@ -1,3 +1,10 @@
+-- @Author: Brian Thurlow
+-- @Date:   06/19/2017 02:19:51 PM
+-- @Last modified by:   Brian Thurlow
+-- @Last modified time: 06/20/2017 02:06:14 PM
+
+
+
 --[[
 AdiBags - Adirelle's bag addon.
 Copyright 2010-2014 Adirelle (adirelle@gmail.com)
@@ -122,6 +129,11 @@ local bankButtonClass, bankButtonProto = addon:NewClass("BankItemButton", "ItemB
 bankButtonClass.frameTemplate = "BankItemButtonGenericTemplate"
 
 function bankButtonProto:OnAcquire(container, bag, slot)
+	self.UpgradeIcon = self:CreateTexture()
+	self.UpgradeIcon:SetAtlas("bags-greenarrow", true)
+	self.UpgradeIcon:SetShown(false)
+	self.UpgradeIcon:ClearAllPoints()
+	self.UpgradeIcon:SetPoint("TOPLEFT",self,"TOPLEFT",0,0)
 	self.GetInventorySlot = nil -- Remove the method added by the template
 	self.inventorySlot = bag == REAGENTBANK_CONTAINER and ReagentBankButtonIDToInvSlotID(slot) or BankButtonIDToInvSlotID(slot)
 	return buttonProto.OnAcquire(self, container, bag, slot)
@@ -140,9 +152,7 @@ function bankButtonProto:GetInventorySlot()
 end
 
 function bankButtonProto:UpdateUpgradeIcon()
-	if self.bag ~= BANK_CONTAINER and self.bag ~= REAGENTBANK_CONTAINER then
 		buttonProto.UpdateUpgradeIcon(self)
-	end
 end
 
 --------------------------------------------------------------------------------
@@ -355,7 +365,16 @@ function buttonProto:UpdateNew()
 end
 
 function buttonProto:UpdateUpgradeIcon()
-	self.UpgradeIcon:SetShown(IsContainerItemAnUpgrade(self.bag, self.slot) or false)
+	if self.UpgradeIcon then
+		local isUpgrade = IsContainerItemAnUpgrade(self.bag, self.slot)
+		if addon.db.profile.modules['ItemLevel'] then
+			local pos = addon.db:GetNamespace('ItemLevel',true).profile.upgIconPos
+			self.UpgradeIcon:ClearAllPoints()
+			self.UpgradeIcon:SetPoint(pos,self,pos)
+		end
+
+		self.UpgradeIcon:SetShown(isUpgrade or false)
+	end
 end
 
 local function GetBorder(bag, slot, itemId, settings)


### PR DESCRIPTION
Fix #195.
Advanced design based on pull 178.

Item Level Text can be set to 9 different positions through the configuration screen.

Upgrade Icon can be set to 9 different positions through the configuration screen.