### PR TITLE
PlaySound changed a bit in 7.3.0, no longer accepts strings

### DIFF
--- a/AdiBags.toc
+++ b/AdiBags.toc
@@ -17,7 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with AdiBags.  If not, see <http://www.gnu.org/licenses/>.
 
-## Interface: 70200
+## Interface: 70300
 
 ## Title: AdiBags
 ## Notes: Adirelle's bag addon.

--- a/AdiBags_Config/AdiBags_Config.toc
+++ b/AdiBags_Config/AdiBags_Config.toc
@@ -1,4 +1,4 @@
-## Interface: 70200
+## Interface: 70300
 
 ## Title: AdiBags Configuration
 ## Notes: Adirelle's bag addon.

--- a/config/Config-ItemList.lua
+++ b/config/Config-ItemList.lua
@@ -54,7 +54,7 @@ do
 		local widget = frame.obj
 		local listWidget = widget:GetUserData('listwidget')
 		if not listWidget then return end
-		PlaySound("igMainMenuOption")
+		PlaySound(SOUNDKIT.IG_MAINMENU_OPTION)
 		local previousId = widget.itemId
 		if previousId then
 			listWidget:Fire("OnValueChanged", previousId, false)

--- a/core/Bags.lua
+++ b/core/Bags.lua
@@ -215,7 +215,7 @@ do
 	end
 
 	function backpack:Sort()
-		PlaySound("UI_BagSorting_01")
+		PlaySound(SOUNDKIT.UI_BAG_SORTING_01)
 		SortBags()
 	end
 end
@@ -282,7 +282,7 @@ do
 	end
 
 	function bank:Sort()
-		PlaySound("UI_BagSorting_01")
+		PlaySound(SOUNDKIT.UI_BAG_SORTING_01)
 		SortBankBags()
 		if IsReagentBankUnlocked() then
 			SortReagentBankBags()

--- a/modules/NewItemTracking.lua
+++ b/modules/NewItemTracking.lua
@@ -90,7 +90,7 @@ local function ResetButton_OnClick(widget, button)
 	if button == "RightButton" then
 		return mod:OpenOptions()
 	end
-	PlaySound("igMainMenuOptionCheckBoxOn")
+	PlaySound(SOUNDKIT.IG_MAINMENU_OPTION_CHECKBOX_ON)
 	C_NewItems.ClearAll()
 	wipe(newItems)
 	mod.button:Disable()

--- a/widgets/BagSlots.lua
+++ b/widgets/BagSlots.lua
@@ -349,7 +349,7 @@ local bankButtonClass, bankButtonProto = addon:NewClass("BankSlotButton", "BagSl
 
 function bankButtonProto:OnClick(button)
 	if self.toPurchase then
-		PlaySound("igMainMenuOption")
+		PlaySound(SOUNDKIT.IG_MAINMENU_OPTION)
 		StaticPopup_Show("CONFIRM_BUY_BANK_SLOT")
 	else
 		return bagButtonProto.OnClick(self, button)

--- a/widgets/ContainerFrame.lua
+++ b/widgets/ContainerFrame.lua
@@ -294,7 +294,7 @@ end
 			if mouseButton == "RightButton" then
 				local enable = not addon.db.profile[optionName]
 				addon.db.profile[optionName] = enable
-				return PlaySound(enable and "igMainMenuOptionCheckBoxOn" or "igMainMenuOptionCheckBoxOff")
+				return PlaySound(enable and SOUNDKIT.IG_MAINMENU_OPTION_CHECKBOX_ON or SOUNDKIT.IG_MAINMENU_OPTION_CHECKBOX_OFF)
 			end
 			onClick()
 		end,
@@ -348,7 +348,7 @@ function containerProto:CreateReagentTabButton()
 		0,
 		function()
 			if not IsReagentBankUnlocked() then
-				PlaySound("igMainMenuOption")
+				PlaySound(SOUNDKIT.IG_MAINMENU_OPTION)
 				return StaticPopup_Show("CONFIRM_BUY_REAGENTBANK_TAB")
 			end
 			self:ShowReagentTab(not self.isReagentBank)
@@ -406,7 +406,7 @@ end
 
 function containerProto:OnShow()
 	self:Debug('OnShow')
-	PlaySound(self.isBank and "igMainMenuOpen" or "igBackPackOpen")
+	PlaySound(self.isBank and SOUNDKIT.IG_MAINMENU_OPEN or SOUNDKIT.IG_BACKPACK_OPEN)
 	self:RegisterEvent('EQUIPMENT_SWAP_PENDING', "PauseUpdates")
 	self:RegisterEvent('EQUIPMENT_SWAP_FINISHED', "ResumeUpdates")
 	self:RegisterEvent('AUCTION_MULTISELL_START', "PauseUpdates")
@@ -418,7 +418,7 @@ end
 
 function containerProto:OnHide()
 	containerParentProto.OnHide(self)
-	PlaySound(self.isBank and "igMainMenuClose" or "igBackPackClose")
+	PlaySound(self.isBank and SOUNDKIT.IG_MAINMENU_CLOSE or SOUNDKIT.IG_BACKPACK_CLOSE)
 	self:PauseUpdates()
 	self:UnregisterAllEvents()
 	self:UnregisterAllMessages()


### PR DESCRIPTION
PlaySound now only will accept a Soundkit ID. I replaced the strings with the Soundkit ID definitions.