### PR TITLE
Fixed lack of color in new item glow

### DIFF
--- a/modules/NewItemTracking.lua
+++ b/modules/NewItemTracking.lua
@@ -210,7 +210,7 @@ end
 
 function mod:ShowBlizzardGlow(button, enable)
 	if enable then
-		local quality = select(4, GetContainerItemInfo(button.bag, button.slot))
+		local _, _, _, quality = GetContainerItemInfo(button.bag, button.slot)
 		if quality and NEW_ITEM_ATLAS_BY_QUALITY[quality] then
 			button.NewItemTexture:SetAtlas(NEW_ITEM_ATLAS_BY_QUALITY[quality])
 		else

--- a/modules/NewItemTracking.lua
+++ b/modules/NewItemTracking.lua
@@ -210,6 +210,7 @@ end
 
 function mod:ShowBlizzardGlow(button, enable)
 	if enable then
+		local quality = select(4, GetContainerItemInfo(button.bag, button.slot))
 		if quality and NEW_ITEM_ATLAS_BY_QUALITY[quality] then
 			button.NewItemTexture:SetAtlas(NEW_ITEM_ATLAS_BY_QUALITY[quality])
 		else


### PR DESCRIPTION
Due to lack of `quality` variable function always used `bags-glow-white` texture.