### PR TITLE
Fixes item swapping issues

### DIFF
--- a/widgets/ItemButton.lua
+++ b/widgets/ItemButton.lua
@@ -570,7 +570,7 @@ function stackProto:Update()
 	self:UpdateVisibleSlot()
 	self:UpdateCount()
 	if self.button then
-		self.button:Update()
+		self.button:FullUpdate()
 	end
 end
 


### PR DESCRIPTION
There is an annoying issue when you swap over two items in bags, they aren't updated as they should, resulting in wrong item stack count, icon, border, etc.

This should fix #93 also.