### PR TITLE
Junk: fix Scrap integration

### DIFF
--- a/modules/Junk.lua
+++ b/modules/Junk.lua
@@ -241,12 +241,24 @@ if Scrap and type(Scrap.IsJunk) == "function" then
 		return (force or prefs.sources.Scrap) and Scrap:IsJunk(itemId)
 	end
 
-	Scrap:HookScript('OnReceiveDrag', function()
+	local function updateScrap()
 		if prefs.sources.Scrap then
 			wipe(cache)
 			addon:SendMessage("AdiBags_FiltersChanged")
 		end
-	end)
+	end
+
+	if Scrap.HookScript then
+		Scrap:HookScript('OnReceiveDrag', updateScrap)
+	end
+
+	if Scrap.Merchant and Scrap.Merchant.HookScript then
+		Scrap.Merchant:HookScript('OnReceiveDrag', updateScrap)
+	end
+
+	if Scrap.ToggleJunk then
+		_G.hooksecurefunc(Scrap, "ToggleJunk", updateScrap)
+	end
 
 	sourceList.Scrap = "Scrap"
 

--- a/modules/Junk.lua
+++ b/modules/Junk.lua
@@ -264,7 +264,10 @@ if Scrap and type(Scrap.IsJunk) == "function" then
 		end
 	end
 
-	Scrap:HookScript('OnReceiveDrag', hook)
+	if Scrap.HookScript then
+		-- Fallback support for older versions; no longer a ScriptObject.
+		Scrap:HookScript('OnReceiveDrag', hook)
+	end
 
 	if Scrap.ToggleJunk then
 		hooksecurefunc(Scrap, 'ToggleJunk', hook)

--- a/modules/Junk.lua
+++ b/modules/Junk.lua
@@ -252,13 +252,23 @@ if Scrap and type(Scrap.IsJunk) == "function" then
 		Scrap:HookScript('OnReceiveDrag', updateScrap)
 	end
 
-	if Scrap.Merchant and Scrap.Merchant.HookScript then
-		Scrap.Merchant:HookScript('OnReceiveDrag', updateScrap)
-	end
-
 	if Scrap.ToggleJunk then
 		_G.hooksecurefunc(Scrap, "ToggleJunk", updateScrap)
 	end
+
+	local frame = _G.CreateFrame("Frame")
+	frame:RegisterEvent("ADDON_LOADED")
+	frame:SetScript("OnEvent", function (_self, _event, name)
+		if name ~= "Scrap_Merchant" then
+			return
+		end
+
+		if Scrap.Merchant and Scrap.Merchant.HookScript then
+			Scrap.Merchant:HookScript('OnReceiveDrag', updateScrap)
+		end
+
+		frame:UnregisterEvent("ADDON_LOADED")
+	end)
 
 	sourceList.Scrap = "Scrap"
 


### PR DESCRIPTION
So I recently installed Scrap and found that it didn't work with AdiBags. This PR fixes that. In addition, it will also update the filter when you use the keybind from Scrap to mark/unmark something as junk.