### PR TITLE
Adding IconOverlay Support

### DIFF
--- a/widgets/ItemButton.lua
+++ b/widgets/ItemButton.lua
@@ -60,7 +60,7 @@ local ITEM_SIZE = addon.ITEM_SIZE
 
 local buttonClass, buttonProto = addon:NewClass("ItemButton", "ItemButton", "ContainerFrameItemButtonTemplate", "ABEvent-1.0")
 
-local childrenNames = { "Cooldown", "IconTexture", "IconQuestTexture", "Count", "Stock", "NormalTexture", "NewItemTexture" }
+local childrenNames = { "Cooldown", "IconTexture", "IconQuestTexture", "Count", "Stock", "NormalTexture", "NewItemTexture", "IconOverlay" }
 
 function buttonProto:OnCreate()
 	local name = self:GetName()
@@ -304,6 +304,7 @@ function buttonProto:Update()
 	else
 		self.Stock:Hide()
 	end
+	self:UpdateOverlay()
 	self:UpdateCount()
 	self:UpdateBorder()
 	self:UpdateCooldown()
@@ -411,6 +412,27 @@ function buttonProto:UpdateBorder(isolatedEvent)
 	end
 	if isolatedEvent then
 		addon:SendMessage('AdiBags_UpdateBorder', self)
+	end
+end
+
+function buttonProto:UpdateOverlay(isolatedEvent)
+	if self.hasItem then
+		local overlay = self.IconOverlay
+		local textureName = nil
+		if C_AzeriteEmpoweredItem.IsAzeriteEmpoweredItemByID(self.itemLink or self.itemId) then
+			textureName = "AzeriteIconFrame"
+		elseif IsCorruptedItem(self.itemLink or self.itemId) then
+			textureName = "Nzoth-inventory-icon"
+		end
+		overlay:Hide();
+		if textureName then
+			overlay:SetAtlas(textureName);
+			overlay:SetBlendMode("BLEND");
+			overlay:Show();
+		end
+	end
+	if isolatedEvent then
+		addon:SendMessage('AdiBags_UpdateOverlay', self)
 	end
 end
 


### PR DESCRIPTION
#### What does this PR do?
Fixes #433 - the lack of the corrupted item overlay (eyeball) and Azerite item overlay (4 corner crystals).

#### Where should the reviewer start?
Have a corrupted gear piece and an azerite gear piece in bags.

#### How should this be manually tested?
- Open bag
- Verify corrupted gear pieces have eyeball in corner
- Verify azerite gear pieces have crystals in corners
- Verify other items display properly

#### Documents
##### Screenshots (if appropriate)
Before:
![image](https://user-images.githubusercontent.com/7342147/79941526-82729500-8432-11ea-894d-bf685200fe32.png)
After:
![image](https://user-images.githubusercontent.com/7342147/79941628-bcdc3200-8432-11ea-8088-fe320a1f84e6.png)

Note: Check marks are from Can I Mog It and can be safely ignored.
