### PR TITLE
Removes embedded BugGrabber

### DIFF
--- a/.pkgmeta
+++ b/.pkgmeta
@@ -13,7 +13,6 @@ externals:
   libs/LibDataBroker-1.1: https://github.com/tekkub/libdatabroker-1-1
   libs/LibSharedMedia-3.0: https://repos.wowace.com/wow/libsharedmedia-3-0/trunk/LibSharedMedia-3.0
   libs/AceGUI-3.0-SharedMediaWidgets: https://repos.wowace.com/wow/ace-gui-3-0-shared-media-widgets/trunk/AceGUI-3.0-SharedMediaWidgets
-  libs/BugGrabber: https://repos.wowace.com/wow/bug-grabber/trunk
 
 move-folders:
   AdiBags/AdiBags_Config: AdiBags_Config

--- a/AdiBags.toc
+++ b/AdiBags.toc
@@ -34,7 +34,6 @@
 #@no-lib-strip@
 libs\LibStub\LibStub.lua
 libs\CallbackHandler-1.0\CallbackHandler-1.0.xml
-libs\BugGrabber\load.xml
 libs\AceAddon-3.0\AceAddon-3.0.xml
 libs\AceDB-3.0\AceDB-3.0.xml
 libs\AceHook-3.0\AceHook-3.0.xml

--- a/README.textile
+++ b/README.textile
@@ -83,8 +83,6 @@ According to my experience with Baggins, comprehensive editor is awful to write 
 
 h2. Feedback
 
-*Important notice:* since v1.6.12-beta-1, AdiBags embeds "BugGrabber":http://www.curse.com/addons/wow/bug-grabber, an error catching addon. Please check the error is really about AdiBags before reporting them here. I suggest installing "BugSack":http://www.curse.com/addons/wow/bugsack to catch the errors.
-
 Some words about submitting bug reports:
 * I do not care about "it doesn't work, fix it!" messages. I need to know how it failed and a way to reproduce the bug so I can test it and make sure I fix it.
 * Bug reports are not in the "fire and forget" kind of things. I may have to ask you some details.


### PR DESCRIPTION
This silently swallows errors from other add-ons
  leading to very confusing behavior

If accepted, this PR fixes #266, fixes #398, fixes #383

For months, I had confusing occasional moments where my UI would just stop working until a reload. I finally tracked it down to this embedded dependency swallowing other add-ons' error messages, and was finally able to fix longstanding issues that were hidden.

I realize my PR here is likely not finished as I'm not entirely sure what all can be removed. I've been playing with the TOC manually edited like this for a while with no issues, but I would like to be able to update cleanly in the future without having to remember to remove this line each time AdiBags updates.