### PR TITLE
Fix for overlapping icons in Manual Filter configuration.

### DIFF
--- a/modules/FilterOverride.lua
+++ b/modules/FilterOverride.lua
@@ -258,6 +258,7 @@ function mod:GetOptions()
 				name = L['Items'],
 				desc = L['Click on a item to remove it from the list. You can drop an item on the empty slot to add it to the list.'],
 				type = 'multiselect',
+				width = 'full',
 				dialogControl = 'ItemList',
 				order = 40,
 				get = function() return true end,

--- a/modules/Junk.lua
+++ b/modules/Junk.lua
@@ -226,6 +226,7 @@ function mod:GetOptions()
 		},
 		include = {
 			type = 'multiselect',
+			width = 'full',
 			dialogControl = 'ItemList',
 			name = L['Include list'],
 			desc = L['Items in this list are always considered as junk. Click an item to remove it from the list.'],
@@ -236,6 +237,7 @@ function mod:GetOptions()
 		},
 		exclude = {
 			type = 'multiselect',
+			width = 'full',
 			dialogControl = 'ItemList',
 			name = L['Exclude list'],
 			desc = L['Items in this list are never considered as junk. Click an item to remove it from the list.'],


### PR DESCRIPTION
Fixes  AdiAddons/AdiBags#278

Before:
![ManualFilterBefore](https://user-images.githubusercontent.com/26781468/96326800-a9c4ac00-0fe8-11eb-818d-a24e3e3c55bf.png)
After:
![ManualFilterAfter](https://user-images.githubusercontent.com/26781468/96326805-b3e6aa80-0fe8-11eb-888f-bd3b9c4a7147.png)

This appears to be caused by a bug in AceConfig.  Setting the width to 'full' avoids triggering the underlying bug as well as improving the appearance of the options gui.

In tracking down the bug I found that the cause of the issue is that the height of the ItemList is calculated with a flow layout and an initial width of 300.  This is done before the ItemList is added to the options frame.  When the ItemList is added to the options frame it uses the current height of the ItemList to expand the layout of the options frame to fit the ItemList.  The width of the ItemList is then changed to 166 and the height gets recalculated because of the flow layout.  This height change is not properly propageted to the parent frame to readjust to fit the now taller and narrower ItemList.  This results in the overlapping frames.


