### PR TITLE
Options to Move ItemLevel text

### DIFF
--- a/modules/ItemLevel.lua
+++ b/modules/ItemLevel.lua
@@ -65,6 +65,9 @@ function mod:OnInitialize()
 			minLevel = 1,
 			ignoreJunk = true,
 			ignoreHeirloom = true,
+			anchor = 'BOTTOMLEFT',
+			offsetX = 2,
+			offsetY = 1,
 		},
 	})
 	if self.db.profile.colored == true then
@@ -85,6 +88,9 @@ function mod:OnInitialize()
 		SyLevel:RegisterFilterOnPipe('Adibags', 'Item level text')
 		SyLevelDB.EnabledFilters['Item level text']['Adibags'] = true
 	end
+	self.db.RegisterCallback(self, "OnProfileChanged", "UpdateTextLocation")
+	self.db.RegisterCallback(self, "OnProfileCopied", "UpdateTextLocation")
+	self.db.RegisterCallback(self, "OnProfileReset", "UpdateTextLocation")
 end
 
 function mod:OnEnable()
@@ -103,10 +109,23 @@ end
 
 local function CreateText(button)
 	local text = button:CreateFontString(nil, "OVERLAY", "NumberFontNormal")
-	text:SetPoint("TOPLEFT", button, 3, -1)
+	local anchor = mod.db.profile.anchor or mod.db.defaults.profile.anchor
+	local offsetX = mod.db.profile.offsetX or mod.db.defaults.profile.offsetX
+	local offsetY = mod.db.profile.offsetY or mod.db.defaults.profile.offsetY
+	text:SetPoint(anchor, button, offsetX, offsetY)
 	text:Hide()
 	texts[button] = text
 	return text
+end
+
+function mod:UpdateTextLocation()
+	local anchor = mod.db.profile.anchor or mod.db.defaults.profile.anchor
+	local offsetX = mod.db.profile.offsetX or mod.db.defaults.profile.offsetX
+	local offsetY = mod.db.profile.offsetY or mod.db.defaults.profile.offsetY
+	for button, text in pairs(texts) do
+		text:ClearAllPoints()
+		text:SetPoint(anchor, button, offsetX, offsetY)
+	end
 end
 
 function mod:UpdateButton(event, button)
@@ -198,6 +217,63 @@ function mod:GetOptions()
 			desc = L['Do not show level of heirloom items.'],
 			type = 'toggle',
 			order = 50,
+		},
+		positionHeader = {
+			name = L['Text Position'],
+			type = 'header',
+			order = 60,
+		},
+		anchor = {
+			name = L['Anchor'],
+			desc = L['Where to anchor the item level text?'],
+			type = 'select',
+			values = {
+				TOPLEFT = L['Top Left'],
+				TOP = L['Top'],
+				TOPRIGHT = L['Top Right'],
+				LEFT = L['Left'],
+				CENTER = L['Center'],
+				RIGHT = L['Right'],
+				BOTTOMLEFT = L['Bottom Left'],
+				BOTTOM = L['Bottom'],
+				BOTTOMRIGHT = L['Bottom Right'],
+				
+			},
+			sorting = {
+				[1] = "TOPLEFT",
+				[2] = "TOP",
+				[3] = "TOPRIGHT",
+				[4] = "LEFT",
+				[5] = "CENTER",
+				[6] = "RIGHT",
+				[7] = "BOTTOMLEFT",
+				[8] = "BOTTOM",
+				[9] = "BOTTOMRIGHT",
+			},
+			order = 61,
+			set = function(info,value) mod.db.profile[info[#info]] = value mod:UpdateTextLocation() end,
+		},
+		offsetX = {
+			name = L['offset right'],
+			desc = L['How far right?'],
+			type = 'range',
+			min = -20,
+			max = 20,
+			step = 1,
+			bigStep = 1,
+			order = 62,
+			set = function(info,value) mod.db.profile[info[#info]] = value mod:UpdateTextLocation() end,
+		},
+		offsetY = {
+			name = L['offset up'],
+			desc = L['How far up?'],
+			type = 'range',
+			min = -20,
+			max = 20,
+			step = 1,
+			bigStep = 1,
+			order = 63,
+			set = function(info,value) mod.db.profile[info[#info]] = value mod:UpdateTextLocation() end,
 		},
 	}, addon:GetOptionHandler(self)
 end


### PR DESCRIPTION

Fixes AdiAddons/AdiBags#303, AdiAddons/AdiBags#323, AdiAddons/AdiBags#327, AdiAddons/AdiBags#376
This is another implementation of pull requests AdiAddons/AdiBags#178 and AdiAddons/AdiBags#206.

Changes the default location of ItemLevel text and adds options for changing text anchor and offsets.

Using the options to change the text back to the old position:
![Location Restored](https://user-images.githubusercontent.com/26781468/96358713-3477da80-10bf-11eb-9b0b-1896fd0fb464.png)
The new **default** location (note that the upgrade icon on the item with an item level 23 is now visible):
![New Location](https://user-images.githubusercontent.com/26781468/96358716-3a6dbb80-10bf-11eb-9ffd-9429a458d1e9.png)

As noted in the bug reports and other pull requests this change mainly focuses on moving the Item Level text so that it doesn't overlap with the UpgradeIcon. I feel this change has merit on its own even for users that do not use the UpgradeIcon.  The ItemLevel plugin does one thing; Display the item level of items in your bag. Having an option of where to display that text seems reasonable.

How this is different from AdiAddons/AdiBags#178
The options allow for setting the text to any location for those who do not want it in the bottom left.
This pull will require localization and AdiAddons/AdiBags#178 does not.
Adds 77 lines of code to allow users to change the behavior of 1 line of code.

How this is different from AdiAddons/AdiBags#206
This implementation does not touch UpgradeIcon and only modifies the behavior of the ItemLevel plugin.
In addition to allowing the anchor to be set the offsets can also be configured.
Implementation of the repositioning is done in a separate function that is only called when the position values change and not in the UpdateButton handler.