### PR TITLE
Toggle hidden bag to foreground

### DIFF
--- a/widgets/ContainerFrame.lua
+++ b/widgets/ContainerFrame.lua
@@ -92,6 +92,10 @@ function addon:CreateContainerFrame(...) return containerClass:Create(...) end
 
 local SimpleLayeredRegion = addon:GetClass("SimpleLayeredRegion")
 
+local frameLevelBag = 0
+local frameLevelBank = 5
+local frameLevelIncrement = 10
+
 local bagSlots = {}
 function containerProto:OnCreate(name, isBank, bagObject)
 	self:SetParent(UIParent)
@@ -100,7 +104,7 @@ function containerProto:OnCreate(name, isBank, bagObject)
 
 	--self:EnableMouse(true)
 	self:SetFrameStrata("HIGH")
-	local frameLevel = 2 + (isBank and 5 or 0)
+	local frameLevel = 2 + (isBank and frameLevelBank or frameLevelBag)
 	self:SetFrameLevel(frameLevel - 2)
 
 	self:SetScript('OnShow', self.OnShow)
@@ -135,7 +139,30 @@ function containerProto:OnCreate(name, isBank, bagObject)
 	local button = CreateFrame("Button", nil, self)
 	button:SetAllPoints(self)
 	button:RegisterForClicks("AnyUp")
-	button:SetScript('OnClick', function(_, ...) return self:OnClick(...) end)
+	button:SetScript('OnClick', function(_, ...)
+		local setForeground = false
+		if isBank and frameLevelBank < frameLevelBag then
+			frameLevelBank = frameLevelBank + frameLevelIncrement
+			setForeground = true
+		elseif not isBank and frameLevelBank > frameLevelBag then
+			frameLevelBag = frameLevelBag + frameLevelIncrement
+			setForeground = true
+		end
+		if setForeground then
+			frameLevel = 2 + (self:GetFrameLevel() + frameLevelIncrement)
+			self:SetFrameLevel(frameLevel - 2)
+			button:SetFrameLevel(frameLevel - 1)
+			headerLeftRegion:SetFrameLevel(frameLevel)
+			headerRightRegion:SetFrameLevel(frameLevel)
+			bottomLeftRegion:SetFrameLevel(frameLevel)
+			bottomRightRegion:SetFrameLevel(frameLevel)
+			closeButton:SetFrameLevel(frameLevel)
+			searchBox:SetFrameLevel(frameLevel)
+			anchor:SetFrameLevel(self:GetFrameLevel() + 10)
+		end
+
+		return self:OnClick(...)
+	end)
 	button:SetScript('OnReceiveDrag', function() return self:OnClick("LeftButton") end)
 	button:SetFrameLevel(frameLevel - 1)
 


### PR DESCRIPTION
See issue: https://github.com/AdiAddons/AdiBags/issues/548

This is a very simple way of bringing the respective container (bag/bank) to the foreground.

To do this, you have to click in the rear container to bring it to the fore. Not the title bar!

Unfortunately I don't know how to implement that better, but it works.

Maybe someone knows a better solution.