### PR TITLE
Fix backdrop errors in TBC.

### DIFF
--- a/core/Layout.lua
+++ b/core/Layout.lua
@@ -24,6 +24,8 @@ local L = addon.L
 
 --<GLOBALS
 local _G = _G
+local BackdropTemplateMixin = _G.BackdropTemplateMixin
+local Mixin = _G.Mixin
 local pairs = _G.pairs
 local type = _G.type
 local UIParent = _G.UIParent
@@ -32,6 +34,9 @@ local wipe = _G.wipe
 
 function addon:CreateBagAnchor()
 	local anchor = self:CreateAnchorWidget(UIParent, "anchor", L["AdiBags Anchor"])
+	if BackdropTemplateMixin then
+		Mixin(anchor, BackdropTemplateMixin)
+	end
 	anchor:SetSize(80, 80)
 	anchor:SetFrameStrata("TOOLTIP")
 	anchor:SetBackdrop({ bgFile = [[Interface\Tooltips\UI-Tooltip-Background]] })

--- a/widgets/AnchorWidget.lua
+++ b/widgets/AnchorWidget.lua
@@ -24,6 +24,7 @@ local L = addon.L
 
 --<GLOBALS
 local _G = _G
+local BackdropTemplateMixin = _G.BackdropTemplateMixin
 local CreateFrame = _G.CreateFrame
 local UIParent = _G.UIParent
 --GLOBALS>
@@ -60,7 +61,7 @@ function anchorProto:OnCreate(parent, name, label, target)
 	self:SetScript('OnMouseUp', self.StopMoving)
 	self:SetScript('OnHide', self.StopMoving)
 
-	local corner = CreateFrame("Frame", nil, self)
+	local corner = CreateFrame("Frame", nil, self, BackdropTemplateMixin and "BackdropTemplate")
 	corner:SetFrameStrata("TOOLTIP")
 	corner:SetBackdrop({ bgFile = [[Interface\Buttons\WHITE8X8]], tile = true, tileSize = 8 })
 	corner:SetBackdropColor(1, 1, 0.5, 0.8)

--- a/widgets/BagSlots.lua
+++ b/widgets/BagSlots.lua
@@ -24,6 +24,7 @@ local L = addon.L
 
 --<GLOBALS
 local _G = _G
+local BackdropTemplateMixin = _G.BackdropTemplateMixin
 local BACKPACK_CONTAINER = _G.BACKPACK_CONTAINER
 local band = _G.bit.band
 local BankFrame = _G.BankFrame
@@ -435,7 +436,7 @@ end
 --------------------------------------------------------------------------------
 
 function addon:CreateBagSlotPanel(container, name, bags, isBank)
-	local self = CreateFrame("Frame", container:GetName().."Bags", container)
+	local self = CreateFrame("Frame", container:GetName().."Bags", container, BackdropTemplateMixin and "BackdropTemplate")
 	self:SetPoint("BOTTOMLEFT", container, "TOPLEFT", 0, 4)
 
 	self.openSound = isBank and SOUNDKIT.IG_MAINMENU_OPEN or SOUNDKIT.IG_BACKPACK_OPEN

--- a/widgets/ContainerFrame.lua
+++ b/widgets/ContainerFrame.lua
@@ -25,6 +25,7 @@ local L = addon.L
 --<GLOBALS
 local _G = _G
 local assert = _G.assert
+local BackdropTemplateMixin = _G.BackdropTemplateMixin
 local BACKPACK_CONTAINER = _G.BACKPACK_CONTAINER
 local band = _G.bit.band
 local BANK_CONTAINER = _G.BANK_CONTAINER
@@ -43,6 +44,7 @@ local GetMerchantItemLink = _G.GetMerchantItemLink
 local ipairs = _G.ipairs
 local max = _G.max
 local min = _G.min
+local Mixin = _G.Mixin
 local next = _G.next
 local NUM_BAG_SLOTS = _G.NUM_BAG_SLOTS
 local pairs = _G.pairs
@@ -96,6 +98,9 @@ local bagSlots = {}
 function containerProto:OnCreate(name, isBank, bagObject)
 	self:SetParent(UIParent)
 	containerParentProto.OnCreate(self)
+	if BackdropTemplateMixin then
+		Mixin(self, BackdropTemplateMixin)
+	end
 
 	--self:EnableMouse(true)
 	self:SetFrameStrata("HIGH")


### PR DESCRIPTION
Fix the backdrop errors in TBC beta client by using the backdrop mixin conditionally.  This version will work on Classic and TBC clients.