### PR TITLE
Unified Codebase for Retail, Classic, and TBC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,17 +1,44 @@
 name: Package and release
+
+# we need to let GitHub know _when_ we want to release, typically only when we create a new tag.
+# this will target only tags, and not all pushes to the master branch.
+# this part can be heavily customized to your liking, like targeting only tags that match a certain word,
+# other branches or even pullrequests.
 on:
   push:
     tags:
       - '**'
+
+# a workflow is built up as jobs, and within these jobs are steps
 jobs:
+
+  # "release" is a job, you can name it anything you want
   release:
+
+    # we can run our steps on pretty much anything, but the "ubuntu-latest" image is a safe bet
     runs-on: ubuntu-latest
+
     env:
-      GITHUB_OAUTH: ${{ secrets.GITHUB_TOKEN }}  
+      GITHUB_OAUTH: ${{ secrets.GITHUB_TOKEN }}  # "GITHUB_TOKEN" is a secret always provided to the workflow
+                                                 # for your own token, the name cannot start with "GITHUB_"
+
+    # "steps" holds a list of all the steps needed to package and release our AddOn
     steps:
+
+      # we first have to clone the AddOn project, this is a required step
       - name: Clone project
         uses: actions/checkout@v3
         with:
           fetch-depth: 0  # gets git history for changelogs
+
+      # once cloned, we just run the GitHub Action for the packager project
       - name: Package and release
         uses: BigWigsMods/packager@v2.0.8
+      - name: Package and release Classic
+        uses: BigWigsMods/packager@v2.0.8
+        with:
+          args: -g classic
+      - name: Package and release TBC
+        uses: BigWigsMods/packager@v2.0.8
+        with:
+          args: -g bcc

--- a/AdiBags.toc
+++ b/AdiBags.toc
@@ -18,6 +18,9 @@
 # along with AdiBags.  If not, see <http://www.gnu.org/licenses/>.
 
 ## Interface: 90207
+## Interface-Retail: 90207
+## Interface-Classic: 11403
+## Interface-BCC: 20504
 
 ## Title: AdiBags
 ## Notes: Adirelle's bag addon.

--- a/AdiBags_Config/AdiBags_Config.toc
+++ b/AdiBags_Config/AdiBags_Config.toc
@@ -1,4 +1,7 @@
 ## Interface: 90207
+## Interface-Retail: 90207
+## Interface-Classic: 11403
+## Interface-BCC: 20504
 
 ## Title: AdiBags Configuration
 ## Notes: Adirelle's bag addon.

--- a/config/Options.lua
+++ b/config/Options.lua
@@ -320,13 +320,6 @@ local function GetOptions()
 								type = 'toggle',
 								order = 95,
 							},
-							autoDeposit = {
-								name = L["Deposit reagents"],
-								desc = L["Automtically deposit all reagents into the reagent bank when you talk to the banker."],
-								type = 'toggle',
-								order = 110,
-								disabled = function() return not IsReagentBankUnlocked() end,
-							},
 						}
 					},
 					position = {
@@ -651,6 +644,15 @@ local function GetOptions()
 		},
 		plugins = {}
 	}
+	if addon.isRetail then
+		options["args"]["bags"]["args"]["automatically"]["args"]["autoDeposit"] = {
+			name = L["Deposit reagents"],
+			desc = L["Automtically deposit all reagents into the reagent bank when you talk to the banker."],
+			type = 'toggle',
+			order = 110,
+			disabled = function() return not IsReagentBankUnlocked() end,
+		}
+	end
 	hooksecurefunc(addon, "OnModuleCreated", OnModuleCreated)
 	for name, module in addon:IterateModules() do
 		OnModuleCreated(addon, module)

--- a/core/Constants.lua
+++ b/core/Constants.lua
@@ -22,6 +22,12 @@ along with AdiBags.  If not, see <http://www.gnu.org/licenses/>.
 local addonName, addon = ...
 local L = addon.L
 
+-- Constants for detecting WoW version.
+addon.isRetail = WOW_PROJECT_ID == WOW_PROJECT_MAINLINE
+addon.isClassic = WOW_PROJECT_ID == WOW_PROJECT_CLASSIC
+addon.isBCC = WOW_PROJECT_ID == WOW_PROJECT_BURNING_CRUSADE_CLASSIC and LE_EXPANSION_LEVEL_CURRENT == LE_EXPANSION_BURNING_CRUSADE
+addon.isWOTLK = WOW_PROJECT_ID == WOW_PROJECT_BURNING_CRUSADE_CLASSIC and LE_EXPANSION_LEVEL_CURRENT == LE_EXPANSION_NORTHREND
+
 --<GLOBALS
 local _G = _G
 local BACKPACK_CONTAINER = _G.BACKPACK_CONTAINER

--- a/core/Constants.lua
+++ b/core/Constants.lua
@@ -37,14 +37,16 @@ local BAGS = { [BACKPACK_CONTAINER] = BACKPACK_CONTAINER }
 for i = 1, NUM_BAG_SLOTS do BAGS[i] = i end
 
 local BANK = {}
+local BANK_ONLY = {}
+local REAGENTBANK_ONLY = {}
 
 if addon.isRetail then
 	-- Base nank bags
-	local BANK_ONLY = { [BANK_CONTAINER] = BANK_CONTAINER }
+	BANK_ONLY = { [BANK_CONTAINER] = BANK_CONTAINER }
 	for i = NUM_BAG_SLOTS + 1, NUM_BAG_SLOTS + NUM_BANKBAGSLOTS do BANK_ONLY[i] = i end
 
 	--- Reagent bank bags
-	local REAGENTBANK_ONLY = { [REAGENTBANK_CONTAINER] = REAGENTBANK_CONTAINER }
+	REAGENTBANK_ONLY = { [REAGENTBANK_CONTAINER] = REAGENTBANK_CONTAINER }
 
 	-- All bank bags
 	for _, bags in ipairs { BANK_ONLY, REAGENTBANK_ONLY } do

--- a/core/Constants.lua
+++ b/core/Constants.lua
@@ -36,17 +36,23 @@ local pairs = _G.pairs
 local BAGS = { [BACKPACK_CONTAINER] = BACKPACK_CONTAINER }
 for i = 1, NUM_BAG_SLOTS do BAGS[i] = i end
 
--- Base nank bags
-local BANK_ONLY = { [BANK_CONTAINER] = BANK_CONTAINER }
-for i = NUM_BAG_SLOTS + 1, NUM_BAG_SLOTS + NUM_BANKBAGSLOTS do BANK_ONLY[i] = i end
-
---- Reagent bank bags
-local REAGENTBANK_ONLY = { [REAGENTBANK_CONTAINER] = REAGENTBANK_CONTAINER }
-
--- All bank bags
 local BANK = {}
-for _, bags in ipairs { BANK_ONLY, REAGENTBANK_ONLY } do
-	for id in pairs(bags) do BANK[id] = id end
+
+if addon.isRetail then
+	-- Base nank bags
+	local BANK_ONLY = { [BANK_CONTAINER] = BANK_CONTAINER }
+	for i = NUM_BAG_SLOTS + 1, NUM_BAG_SLOTS + NUM_BANKBAGSLOTS do BANK_ONLY[i] = i end
+
+	--- Reagent bank bags
+	local REAGENTBANK_ONLY = { [REAGENTBANK_CONTAINER] = REAGENTBANK_CONTAINER }
+
+	-- All bank bags
+	for _, bags in ipairs { BANK_ONLY, REAGENTBANK_ONLY } do
+		for id in pairs(bags) do BANK[id] = id end
+	end
+else
+	BANK = { [BANK_CONTAINER] = BANK_CONTAINER }
+	for i = NUM_BAG_SLOTS + 1, NUM_BAG_SLOTS + NUM_BANKBAGSLOTS do BANK[i] = i end
 end
 
 -- All bags

--- a/core/Core.lua
+++ b/core/Core.lua
@@ -126,7 +126,9 @@ function addon:OnEnable()
 	self:RegisterEvent('BAG_UPDATE')
 	self:RegisterEvent('BAG_UPDATE_DELAYED')
 	self:RegisterBucketEvent('PLAYERBANKSLOTS_CHANGED', 0.01, 'BankUpdated')
-	self:RegisterBucketEvent('PLAYERREAGENTBANKSLOTS_CHANGED', 0.01, 'ReagentBankUpdated')
+	if addon.isRetail then
+		self:RegisterBucketEvent('PLAYERREAGENTBANKSLOTS_CHANGED', 0.01, 'ReagentBankUpdated')
+	end
 
 	self:RegisterEvent('PLAYER_LEAVING_WORLD', 'Disable')
 

--- a/core/Core.lua
+++ b/core/Core.lua
@@ -325,7 +325,10 @@ addon:SetDefaultModulePrototype(moduleProto)
 
 local updatedBags = {}
 local updatedBank = { [BANK_CONTAINER] = true }
-local updatedReagentBank = { [REAGENTBANK_CONTAINER] = true }
+local updatedReagentBank = {}
+if addon.isRetail then
+	updatedReagentBank = { [REAGENTBANK_CONTAINER] = true }
+end
 
 function addon:BAG_UPDATE(event, bag)
 	updatedBags[bag] = true

--- a/core/DefaultFilters.lua
+++ b/core/DefaultFilters.lua
@@ -72,7 +72,7 @@ function addon:SetupDefaultFilters()
 			local setFilter = addon:RegisterFilter("ItemSets", 90, "ABEvent-1.0", "ABBucket-1.0")
 			setFilter.uiName = L['Gear manager item sets']
 			setFilter.uiDesc = L['Put items belonging to one or more sets of the built-in gear manager in specific sections.']
-		
+
 			function setFilter:OnInitialize()
 				self.db = addon.db:RegisterNamespace('ItemSets', {
 					profile = { oneSectionPerSet = true },
@@ -81,16 +81,16 @@ function addon:SetupDefaultFilters()
 				self.names = {}
 				self.slots = {}
 			end
-		
+
 			function setFilter:OnEnable()
 				self:RegisterEvent('EQUIPMENT_SETS_CHANGED')
 				self:RegisterMessage("AdiBags_PreFilter")
 				self:RegisterMessage("AdiBags_PreContentUpdate")
 				self:UpdateNames()
 			end
-		
+
 			local GetSlotId = addon.GetSlotId
-		
+
 			function setFilter:UpdateNames()
 				self:Debug('Updating names')
 				wipe(self.names)
@@ -100,7 +100,7 @@ function addon:SetupDefaultFilters()
 				end
 				self.dirty = true
 			end
-		
+
 			function setFilter:UpdateSlots()
 				self:Debug('Updating slots')
 				wipe(self.slots)
@@ -132,22 +132,22 @@ function addon:SetupDefaultFilters()
 				end
 				self.dirty = not missing
 			end
-		
+
 			function setFilter:EQUIPMENT_SETS_CHANGED(event)
 				self:UpdateNames()
 				self:SendMessage('AdiBags_FiltersChanged', true)
 			end
-		
+
 			function setFilter:AdiBags_PreContentUpdate(event)
 				self.dirty = true
 			end
-		
+
 			function setFilter:AdiBags_PreFilter(event)
 				if self.dirty then
 					self:UpdateSlots()
 				end
 			end
-		
+
 			local SETS, SET_NAME =  L['Sets'], L["Set: %s"]
 			function setFilter:Filter(slotData)
 				local name = self.slots[slotData.slotId]
@@ -159,7 +159,7 @@ function addon:SetupDefaultFilters()
 					end
 				end
 			end
-		
+
 			function setFilter:GetOptions()
 				return {
 					oneSectionPerSet = {
@@ -185,7 +185,7 @@ function addon:SetupDefaultFilters()
 					},
 				}, addon:GetOptionHandler(self, true)
 			end
-		
+
 		end
 	end
 
@@ -307,20 +307,23 @@ function addon:SetupDefaultFilters()
 		end
 
 		function itemCat:GetOptions()
+			local values = {
+				[TRADE_GOODS] = TRADE_GOODS,
+				[CONSUMMABLE] = CONSUMMABLE,
+				[MISCELLANEOUS] = MISCELLANEOUS,
+				[RECIPE] = RECIPE,
+			}
+			if addon.isRetail then
+				values[GEM] = GEM
+				values[GLYPH] = GLYPH
+			end
 			return {
 				splitBySubclass = {
 					name = L['Split by subcategories'],
 					desc = L['Select which first-level categories should be split by sub-categories.'],
 					type = 'multiselect',
 					order = 10,
-					values = {
-						[TRADE_GOODS] = TRADE_GOODS,
-						[CONSUMMABLE] = CONSUMMABLE,
-						[MISCELLANEOUS] = MISCELLANEOUS,
-						[GEM] = GEM,
-						[GLYPH] = GLYPH,
-						[RECIPE] = RECIPE,
-					}
+					values = values
 				},
 				mergeGems = {
 					name = L['Gems are trade goods'],

--- a/core/DefaultFilters.lua
+++ b/core/DefaultFilters.lua
@@ -67,124 +67,126 @@ function addon:SetupDefaultFilters()
 	}
 
 	-- [90] Parts of an equipment set
-	do
-		local setFilter = addon:RegisterFilter("ItemSets", 90, "ABEvent-1.0", "ABBucket-1.0")
-		setFilter.uiName = L['Gear manager item sets']
-		setFilter.uiDesc = L['Put items belonging to one or more sets of the built-in gear manager in specific sections.']
-
-		function setFilter:OnInitialize()
-			self.db = addon.db:RegisterNamespace('ItemSets', {
-				profile = { oneSectionPerSet = true },
-				char = { mergedSets = { ['*'] = false } },
-			})
-			self.names = {}
-			self.slots = {}
-		end
-
-		function setFilter:OnEnable()
-			self:RegisterEvent('EQUIPMENT_SETS_CHANGED')
-			self:RegisterMessage("AdiBags_PreFilter")
-			self:RegisterMessage("AdiBags_PreContentUpdate")
-			self:UpdateNames()
-		end
-
-		local GetSlotId = addon.GetSlotId
-
-		function setFilter:UpdateNames()
-			self:Debug('Updating names')
-			wipe(self.names)
-			for _, equipmentSetID in pairs(GetEquipmentSetIDs()) do
-				local name = GetEquipmentSetInfo(equipmentSetID)
-				self.names[name] = name
+	if addon.isRetail then
+		do
+			local setFilter = addon:RegisterFilter("ItemSets", 90, "ABEvent-1.0", "ABBucket-1.0")
+			setFilter.uiName = L['Gear manager item sets']
+			setFilter.uiDesc = L['Put items belonging to one or more sets of the built-in gear manager in specific sections.']
+		
+			function setFilter:OnInitialize()
+				self.db = addon.db:RegisterNamespace('ItemSets', {
+					profile = { oneSectionPerSet = true },
+					char = { mergedSets = { ['*'] = false } },
+				})
+				self.names = {}
+				self.slots = {}
 			end
-			self.dirty = true
-		end
-
-		function setFilter:UpdateSlots()
-			self:Debug('Updating slots')
-			wipe(self.slots)
-			local missing = false
-			for _, equipmentSetID in pairs(GetEquipmentSetIDs()) do
-				local name = GetEquipmentSetInfo(equipmentSetID)
-				local itemIDs = GetItemIDs(equipmentSetID)
-				local locations = GetItemLocations(equipmentSetID)
-				if itemIDs and locations then
-					for invId, location in pairs(locations) do
-						if location ~= 0 and location ~= 1 and itemIDs[invId] ~= 0 then
-							local player, bank, bags, voidstorage, slot, container  = EquipmentManager_UnpackLocation(location)
-							local slotId
-							if bags and slot and container then
-								slotId = GetSlotId(container, slot)
-							elseif bank and slot then
-								slotId = GetSlotId(BANK_CONTAINER, slot - BANK_CONTAINER_INVENTORY_OFFSET)
-							elseif not (player or voidstorage) or not slot then
-								missing = true
-							end
-							if slotId and not self.slots[slotId] then
-								self.slots[slotId] = name
+		
+			function setFilter:OnEnable()
+				self:RegisterEvent('EQUIPMENT_SETS_CHANGED')
+				self:RegisterMessage("AdiBags_PreFilter")
+				self:RegisterMessage("AdiBags_PreContentUpdate")
+				self:UpdateNames()
+			end
+		
+			local GetSlotId = addon.GetSlotId
+		
+			function setFilter:UpdateNames()
+				self:Debug('Updating names')
+				wipe(self.names)
+				for _, equipmentSetID in pairs(GetEquipmentSetIDs()) do
+					local name = GetEquipmentSetInfo(equipmentSetID)
+					self.names[name] = name
+				end
+				self.dirty = true
+			end
+		
+			function setFilter:UpdateSlots()
+				self:Debug('Updating slots')
+				wipe(self.slots)
+				local missing = false
+				for _, equipmentSetID in pairs(GetEquipmentSetIDs()) do
+					local name = GetEquipmentSetInfo(equipmentSetID)
+					local itemIDs = GetItemIDs(equipmentSetID)
+					local locations = GetItemLocations(equipmentSetID)
+					if itemIDs and locations then
+						for invId, location in pairs(locations) do
+							if location ~= 0 and location ~= 1 and itemIDs[invId] ~= 0 then
+								local player, bank, bags, voidstorage, slot, container  = EquipmentManager_UnpackLocation(location)
+								local slotId
+								if bags and slot and container then
+									slotId = GetSlotId(container, slot)
+								elseif bank and slot then
+									slotId = GetSlotId(BANK_CONTAINER, slot - BANK_CONTAINER_INVENTORY_OFFSET)
+								elseif not (player or voidstorage) or not slot then
+									missing = true
+								end
+								if slotId and not self.slots[slotId] then
+									self.slots[slotId] = name
+								end
 							end
 						end
+					else
+						missing = true
 					end
-				else
-					missing = true
+				end
+				self.dirty = not missing
+			end
+		
+			function setFilter:EQUIPMENT_SETS_CHANGED(event)
+				self:UpdateNames()
+				self:SendMessage('AdiBags_FiltersChanged', true)
+			end
+		
+			function setFilter:AdiBags_PreContentUpdate(event)
+				self.dirty = true
+			end
+		
+			function setFilter:AdiBags_PreFilter(event)
+				if self.dirty then
+					self:UpdateSlots()
 				end
 			end
-			self.dirty = not missing
-		end
-
-		function setFilter:EQUIPMENT_SETS_CHANGED(event)
-			self:UpdateNames()
-			self:SendMessage('AdiBags_FiltersChanged', true)
-		end
-
-		function setFilter:AdiBags_PreContentUpdate(event)
-			self.dirty = true
-		end
-
-		function setFilter:AdiBags_PreFilter(event)
-			if self.dirty then
-				self:UpdateSlots()
-			end
-		end
-
-		local SETS, SET_NAME =  L['Sets'], L["Set: %s"]
-		function setFilter:Filter(slotData)
-			local name = self.slots[slotData.slotId]
-			if name then
-				if not self.db.profile.oneSectionPerSet or self.db.char.mergedSets[name] then
-					return SETS, EQUIPMENT
-				else
-					return format(SET_NAME, name), EQUIPMENT
+		
+			local SETS, SET_NAME =  L['Sets'], L["Set: %s"]
+			function setFilter:Filter(slotData)
+				local name = self.slots[slotData.slotId]
+				if name then
+					if not self.db.profile.oneSectionPerSet or self.db.char.mergedSets[name] then
+						return SETS, EQUIPMENT
+					else
+						return format(SET_NAME, name), EQUIPMENT
+					end
 				end
 			end
+		
+			function setFilter:GetOptions()
+				return {
+					oneSectionPerSet = {
+						name = L['One section per set'],
+						desc = L['Check this to display one individual section per set. If this is disabled, there will be one big "Sets" section.'],
+						type = 'toggle',
+						order = 10,
+					},
+					mergedSets = {
+						name = L['Merged sets'],
+						desc = L['Check sets that should be merged into a unique "Sets" section. This is obviously a per-character setting.'],
+						type = 'multiselect',
+						order = 20,
+						values = self.names,
+						get = function(info, name)
+							return self.db.char.mergedSets[name]
+						end,
+						set = function(info, name, value)
+							self.db.char.mergedSets[name] = value
+							self:SendMessage('AdiBags_FiltersChanged')
+						end,
+						disabled = function() return not self.db.profile.oneSectionPerSet end,
+					},
+				}, addon:GetOptionHandler(self, true)
+			end
+		
 		end
-
-		function setFilter:GetOptions()
-			return {
-				oneSectionPerSet = {
-					name = L['One section per set'],
-					desc = L['Check this to display one individual section per set. If this is disabled, there will be one big "Sets" section.'],
-					type = 'toggle',
-					order = 10,
-				},
-				mergedSets = {
-					name = L['Merged sets'],
-					desc = L['Check sets that should be merged into a unique "Sets" section. This is obviously a per-character setting.'],
-					type = 'multiselect',
-					order = 20,
-					values = self.names,
-					get = function(info, name)
-						return self.db.char.mergedSets[name]
-					end,
-					set = function(info, name, value)
-						self.db.char.mergedSets[name] = value
-						self:SendMessage('AdiBags_FiltersChanged')
-					end,
-					disabled = function() return not self.db.profile.oneSectionPerSet end,
-				},
-			}, addon:GetOptionHandler(self, true)
-		end
-
 	end
 
 	-- [75] Quest Items
@@ -193,8 +195,12 @@ function addon:SetupDefaultFilters()
 			if slotData.class == QUEST or slotData.subclass == QUEST then
 				return QUEST
 			else
-				local isQuestItem, questId = GetContainerItemQuestInfo(slotData.bag, slotData.slot)
-				return (questId or isQuestItem) and QUEST
+				if addon.isRetail then
+					local isQuestItem, questId = GetContainerItemQuestInfo(slotData.bag, slotData.slot)
+					return (questId or isQuestItem) and QUEST
+				else
+					return false
+				end
 			end
 		end)
 		questItemFilter.uiName = L['Quest Items']

--- a/core/DefaultFilters.lua
+++ b/core/DefaultFilters.lua
@@ -307,16 +307,25 @@ function addon:SetupDefaultFilters()
 		end
 
 		function itemCat:GetOptions()
-			local values = {
-				[TRADE_GOODS] = TRADE_GOODS,
-				[CONSUMMABLE] = CONSUMMABLE,
-				[MISCELLANEOUS] = MISCELLANEOUS,
-				[RECIPE] = RECIPE,
-			}
+			local values = {}
 			if addon.isRetail then
-				values[GEM] = GEM
-				values[GLYPH] = GLYPH
+				values = {
+					[TRADE_GOODS] = TRADE_GOODS,
+					[CONSUMMABLE] = CONSUMMABLE,
+					[MISCELLANEOUS] = MISCELLANEOUS,
+					[GEM] = GEM,
+					[GLYPH] = GLYPH,
+					[RECIPE] = RECIPE,
+				}
+			else
+				values = {
+					[TRADE_GOODS] = TRADE_GOODS,
+					[CONSUMMABLE] = CONSUMMABLE,
+					[MISCELLANEOUS] = MISCELLANEOUS,
+					[RECIPE] = RECIPE,
+				}
 			end
+
 			return {
 				splitBySubclass = {
 					name = L['Split by subcategories'],

--- a/core/Utility.lua
+++ b/core/Utility.lua
@@ -51,11 +51,6 @@ local type = _G.type
 local FAMILY_TAGS = addon.FAMILY_TAGS
 local FAMILY_ICONS = addon.FAMILY_ICONS
 
-addon.isRetail = WOW_PROJECT_ID == WOW_PROJECT_MAINLINE
-addon.isClassic = WOW_PROJECT_ID == WOW_PROJECT_CLASSIC
-addon.isBCC = WOW_PROJECT_ID == WOW_PROJECT_BURNING_CRUSADE_CLASSIC and LE_EXPANSION_LEVEL_CURRENT == LE_EXPANSION_BURNING_CRUSADE
-addon.isWOTLK = WOW_PROJECT_ID == WOW_PROJECT_BURNING_CRUSADE_CLASSIC and LE_EXPANSION_LEVEL_CURRENT == LE_EXPANSION_NORTHREND
-
 --------------------------------------------------------------------------------
 -- (bag,slot) <=> slotId conversion
 --------------------------------------------------------------------------------

--- a/core/Utility.lua
+++ b/core/Utility.lua
@@ -45,10 +45,16 @@ local strsplit = _G.strsplit
 local tonumber = _G.tonumber
 local tostring = _G.tostring
 local type = _G.type
+
 --GLOBALS>
 
 local FAMILY_TAGS = addon.FAMILY_TAGS
 local FAMILY_ICONS = addon.FAMILY_ICONS
+
+addon.isRetail = WOW_PROJECT_ID == WOW_PROJECT_MAINLINE
+addon.isClassic = WOW_PROJECT_ID == WOW_PROJECT_CLASSIC
+addon.isBCC = WOW_PROJECT_ID == WOW_PROJECT_BURNING_CRUSADE_CLASSIC and LE_EXPANSION_LEVEL_CURRENT == LE_EXPANSION_BURNING_CRUSADE
+addon.isWOTLK = WOW_PROJECT_ID == WOW_PROJECT_BURNING_CRUSADE_CLASSIC and LE_EXPANSION_LEVEL_CURRENT == LE_EXPANSION_NORTHREND
 
 --------------------------------------------------------------------------------
 -- (bag,slot) <=> slotId conversion

--- a/install-deps.sh
+++ b/install-deps.sh
@@ -9,6 +9,6 @@ svn checkout https://repos.wowace.com/wow/ace3/trunk/AceHook-3.0 ./libs/AceHook-
 svn checkout https://repos.wowace.com/wow/ace3/trunk/AceGUI-3.0 ./libs/AceGUI-3.0
 svn checkout https://repos.wowace.com/wow/ace3/trunk/AceConsole-3.0 ./libs/AceConsole-3.0
 svn checkout https://repos.wowace.com/wow/ace3/trunk/AceConfig-3.0 ./libs/AceConfig-3.0
-svn checkout https://github.com/tekkub/libdatabroker-1-1 ./libs/LibDataBroker-1.1
+git clone https://github.com/tekkub/libdatabroker-1-1 ./libs/LibDataBroker-1.1
 svn checkout https://repos.wowace.com/wow/libsharedmedia-3-0/trunk/LibSharedMedia-3.0 ./libs/LibSharedMedia-3.0
 svn checkout https://repos.wowace.com/wow/ace-gui-3-0-shared-media-widgets/trunk/AceGUI-3.0-SharedMediaWidgets ./libs/AceGUI-3.0-SharedMediaWidgets

--- a/modules/CurrencyFrame.lua
+++ b/modules/CurrencyFrame.lua
@@ -22,6 +22,11 @@ along with AdiBags.  If not, see <http://www.gnu.org/licenses/>.
 local addonName, addon = ...
 local L = addon.L
 
+-- Don't load this file at all unless AdiBags is in retail.
+if not addon.isRetail then
+	return
+end
+
 --<GLOBALS
 local _G = _G
 local BreakUpLargeNumbers = _G.BreakUpLargeNumbers

--- a/modules/ItemLevel.lua
+++ b/modules/ItemLevel.lua
@@ -118,6 +118,14 @@ local function CreateText(button)
 end
 
 function mod:UpdateButton(event, button)
+	if addon.isRetail then
+		mod:UpdateButton_Retail(event, button)
+	else
+		mod:UpdateButton_Classic(event, button)
+	end
+end
+
+function mod:UpdateButton_Retail(event, button)
 	local settings = self.db.profile
 	local text = texts[button]
 	local link = button:GetItemLink()
@@ -182,6 +190,46 @@ function mod:UpdateButton(event, button)
 		if text then text:Hide() end
 	end
 	updateCache[button] = link
+end
+
+function mod:UpdateButton_Classic(event, button)
+	local settings = self.db.profile
+	local link = button:GetItemLink()
+	local text = texts[button]
+
+	if link then
+		local _, _, quality, _, reqLevel, _, _, _, loc = GetItemInfo(link)
+		local item = Item:CreateFromBagAndSlot(button.bag, button.slot)
+		local level = item and item:GetCurrentItemLevel() or 0
+		if level >= settings.minLevel
+			and (quality ~= LE_ITEM_QUALITY_POOR or not settings.ignoreJunk)
+			and (loc ~= "" or not settings.equippableOnly)
+		then
+			if SyLevel then
+				if settings.useSyLevel then
+					if text then
+						text:Hide()
+					end
+					SyLevel:CallFilters('Adibags', button, link)
+					return
+				else
+					SyLevel:CallFilters('Adibags', button, nil)
+				end
+			end
+			if not text then
+				text = CreateText(button)
+			end
+			text:SetText(level)
+			text:SetTextColor(colorSchemes[settings.colorScheme](level, quality, reqLevel, (loc ~= "")))
+			return text:Show()
+		end
+	end
+	if SyLevel then
+		SyLevel:CallFilters('Adibags', button, nil)
+	end
+	if text then
+		text:Hide()
+	end
 end
 
 local function SetOptionAndUpdate(info, value)

--- a/modules/ItemLevel.lua
+++ b/modules/ItemLevel.lua
@@ -37,7 +37,10 @@ local pairs = _G.pairs
 local select = _G.select
 local unpack = _G.unpack
 local wipe = _G.wipe
-local ExtractLink = _G.LinkUtil.ExtractLink
+local ExtractLink
+if addon.isRetail then
+	ExtractLink = _G.LinkUtil.ExtractLink
+end
 --GLOBALS>
 
 local mod = addon:NewModule('ItemLevel', 'ABEvent-1.0')

--- a/modules/Junk.lua
+++ b/modules/Junk.lua
@@ -29,8 +29,15 @@ local GameTooltip = _G.GameTooltip
 local GetItemInfo = _G.GetItemInfo
 local hooksecurefunc = _G.hooksecurefunc
 local IsAddOnLoaded = _G.IsAddOnLoaded
-local ITEM_QUALITY_POOR = _G.Enum.ItemQuality.Poor
-local ITEM_QUALITY_UNCOMMON = _G.Enum.ItemQuality.Uncommon
+local ITEM_QUALITY_POOR
+local ITEM_QUALITY_UNCOMMON
+if addon.isRetail then
+	ITEM_QUALITY_POOR = _G.Enum.ItemQuality.Poor
+	ITEM_QUALITY_UNCOMMON = _G.Enum.ItemQuality.Uncommon
+else
+	ITEM_QUALITY_POOR = _G.LE_ITEM_QUALITY_POOR
+	ITEM_QUALITY_UNCOMMON = _G.LE_ITEM_QUALITY_UNCOMMON
+end
 local print = _G.print
 local select = _G.select
 local setmetatable = _G.setmetatable

--- a/widgets/BagSlots.lua
+++ b/widgets/BagSlots.lua
@@ -215,8 +215,12 @@ end
 --------------------------------------------------------------------------------
 -- Regular bag buttons
 --------------------------------------------------------------------------------
-
-local bagButtonClass, bagButtonProto = addon:NewClass("BagSlotButton", "ItemButton", nil, "ABEvent-1.0")
+local bagButtonClass, bagButtonProto
+if addon.isRetail then
+	bagButtonClass, bagButtonProto = addon:NewClass("BagSlotButton", "ItemButton", nil, "ABEvent-1.0")
+else
+	bagButtonClass, bagButtonProto = addon:NewClass("BagSlotButton", "Button", "ItemButtonTemplate", "ABEvent-1.0")
+end
 
 function bagButtonProto:OnCreate(bag)
 	self.bag = bag

--- a/widgets/ContainerFrame.lua
+++ b/widgets/ContainerFrame.lua
@@ -209,12 +209,13 @@ function containerProto:OnCreate(name, isBank, bagObject)
 	anchor:SetFrameLevel(self:GetFrameLevel() + 10)
 	self.Anchor = anchor
 
-	if self.isBank then
-		self:CreateReagentTabButton()
-		self:CreateDepositButton()
+	if addon.isRetail then
+		if self.isBank then
+			self:CreateReagentTabButton()
+			self:CreateDepositButton()
+		end
+		self:CreateSortButton()
 	end
-	self:CreateSortButton()
-
 	local toSortSection = addon:AcquireSection(self, L["Recent Items"], self.name)
 	toSortSection:SetPoint("TOPLEFT", BAG_INSET, -addon.TOP_PADDING)
 	toSortSection:Show()
@@ -380,11 +381,18 @@ end
 --------------------------------------------------------------------------------
 
 function containerProto:GetBagIds()
-	return BAG_IDS[
-		self.isReagentBank and "REAGENTBANK_ONLY" or
-		self.isBank and "BANK_ONLY" or
-		"BAGS"
-	]
+	if addon.isRetail then
+		return BAG_IDS[
+			self.isReagentBank and "REAGENTBANK_ONLY" or
+			self.isBank and "BANK_ONLY" or
+			"BAGS"
+		]
+	else
+		return BAG_IDS[
+			self.isBank and "BANK" or
+			"BAGS"
+		]
+	end
 end
 
 function containerProto:BagsUpdated(event, bagIds)

--- a/widgets/ContainerFrame.lua
+++ b/widgets/ContainerFrame.lua
@@ -252,14 +252,16 @@ function containerProto:OnCreate(name, isBank, bagObject)
 	RegisterMessage(name, 'AdiBags_LayoutChanged', self.FullUpdate, self)
 	RegisterMessage(name, 'AdiBags_ConfigChanged', self.ConfigChanged, self)
 	RegisterMessage(name, 'AdiBags_ForceFullLayout', ForceFullLayout)
-	LibStub('ABEvent-1.0').RegisterEvent(name, 'EQUIPMENT_SWAP_FINISHED', ForceFullLayout)
+	if addon.isRetail then
+		LibStub('ABEvent-1.0').RegisterEvent(name, 'EQUIPMENT_SWAP_FINISHED', ForceFullLayout)
 
-	-- Force full layout on sort
-	if isBank then
-		hooksecurefunc('SortBankBags', ForceFullLayout)
-		hooksecurefunc('SortReagentBankBags', ForceFullLayout)
-	else
-		hooksecurefunc('SortBags', ForceFullLayout)
+		-- Force full layout on sort
+		if isBank then
+			hooksecurefunc('SortBankBags', ForceFullLayout)
+			hooksecurefunc('SortReagentBankBags', ForceFullLayout)
+		else
+			hooksecurefunc('SortBags', ForceFullLayout)
+		end
 	end
 end
 

--- a/widgets/ItemButton.lua
+++ b/widgets/ItemButton.lua
@@ -315,7 +315,9 @@ function buttonProto:Update()
 	self:UpdateCooldown()
 	self:UpdateLock()
 	self:UpdateNew()
-	self:UpdateUpgradeIcon()
+	if addon.isRetail then
+		self:UpdateUpgradeIcon()
+	end
 	if self.UpdateSearch then
 		self:UpdateSearch()
 	end
@@ -373,13 +375,15 @@ if addon.isRetail then
 end
 
 local function GetBorder(bag, slot, itemId, settings)
-	if settings.questIndicator then
-		local isQuestItem, questId, isActive = GetContainerItemQuestInfo(bag, slot)
-		if questId and not isActive then
-			return TEXTURE_ITEM_QUEST_BANG
-		end
-		if questId or isQuestItem then
-			return TEXTURE_ITEM_QUEST_BORDER
+	if addon.isRetail then
+		if settings.questIndicator then
+			local isQuestItem, questId, isActive = GetContainerItemQuestInfo(bag, slot)
+			if questId and not isActive then
+				return TEXTURE_ITEM_QUEST_BANG
+			end
+			if questId or isQuestItem then
+				return TEXTURE_ITEM_QUEST_BORDER
+			end
 		end
 	end
 	if not settings.qualityHighlight then

--- a/widgets/ItemButton.lua
+++ b/widgets/ItemButton.lua
@@ -363,11 +363,13 @@ function buttonProto:UpdateNew()
 	self.BattlepayItemTexture:SetShown(IsBattlePayItem(self.bag, self.slot))
 end
 
-function buttonProto:UpdateUpgradeIcon()
-	-- Use Pawn's (third-party addon) function if present; else fallback to Blizzard's.
-	local PawnIsContainerItemAnUpgrade = _G.PawnIsContainerItemAnUpgrade
-	local itemIsUpgrade = PawnIsContainerItemAnUpgrade and PawnIsContainerItemAnUpgrade(self.bag, self.slot) or IsContainerItemAnUpgrade(self.bag, self.slot)
-	self.UpgradeIcon:SetShown(itemIsUpgrade or false)
+if addon.isRetail then
+	function buttonProto:UpdateUpgradeIcon()
+		-- Use Pawn's (third-party addon) function if present; else fallback to Blizzard's.
+		local PawnIsContainerItemAnUpgrade = _G.PawnIsContainerItemAnUpgrade
+		local itemIsUpgrade = PawnIsContainerItemAnUpgrade and PawnIsContainerItemAnUpgrade(self.bag, self.slot) or IsContainerItemAnUpgrade(self.bag, self.slot)
+		self.UpgradeIcon:SetShown(itemIsUpgrade or false)
+	end
 end
 
 local function GetBorder(bag, slot, itemId, settings)

--- a/widgets/ItemButton.lua
+++ b/widgets/ItemButton.lua
@@ -59,7 +59,12 @@ local ITEM_SIZE = addon.ITEM_SIZE
 -- Button initialization
 --------------------------------------------------------------------------------
 
-local buttonClass, buttonProto = addon:NewClass("ItemButton", "ItemButton", "ContainerFrameItemButtonTemplate", "ABEvent-1.0")
+local buttonClass, buttonProto
+if addon.isRetail then
+	buttonClass, buttonProto = addon:NewClass("ItemButton", "ItemButton", "ContainerFrameItemButtonTemplate", "ABEvent-1.0")
+else
+	buttonClass, buttonProto = addon:NewClass("ItemButton", "Button", "ContainerFrameItemButtonTemplate", "ABEvent-1.0")
+end
 
 local childrenNames = { "Cooldown", "IconTexture", "IconQuestTexture", "Count", "Stock", "NormalTexture", "NewItemTexture" }
 


### PR DESCRIPTION
This CL resolves #646 and fully unifies the codebase for all three versions of World of Warcraft on the market. It works by adding 4 new constants to Constants.lua that can determine the running version at runtime. These constants are then used to conditionally branch various parts of the code so AdiBags works across all three releases from a single codebase.

This CL also adds support for building all three versions via BigWigsMods packager under a single git tag. At any point after this CL, simply upload a new tag and the Github action tied to this repo will build the correct artifacts for each version of WoW.

Things to note:

* Some parts of the code that are "dead" and unused are not conditionally escaped for classic. This is intentional and harmless, as the code is never actually run, and there's no use in escaping it
* Only code that is actively executed by WoW and needs to be changed has been modified
* The config screen still needs a few changes for classic, i.e. there are still references to glyphs
* This has not been tested with the coming WotLK release, but will be addressed when pre-patch is released with the new API's

I've tested on retail, classic, and classic era:
* Bags
* Filters
* Bank Bags
* Reagent Bags
* Void Storage

I've encountered no obvious bugs. @Talyrius Can you do a quick lookover and see if this looks good? I know you're not around much, which is fine -- if I don't hear from you by sometime next week, I'll go ahead and merge this.

Thanks!