### PR TITLE
Correctly detect new items that are wrapped

### DIFF
--- a/modules/NewItemTracking.lua
+++ b/modules/NewItemTracking.lua
@@ -73,6 +73,7 @@ function mod:OnEnable()
 	end
 
 	self:RegisterMessage('AdiBags_UpdateButton', 'UpdateButton')
+	self:RegisterMessage('AdiBags_AddNewItem', 'AddNewItem')
 	self:RegisterEvent('BAG_NEW_ITEMS_UPDATED')
 end
 
@@ -122,6 +123,10 @@ end
 
 function mod:UpdateModuleButton()
 	self.button:SetEnabled(next(newItems) or self.container.ToSortSection:IsShown())
+end
+
+function mod:AddNewItem(event, link)
+	newItems[link] = true
 end
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
This CL will correctly detect wrapped items and mark them as "new" items in AdiBags. Additionally, this CL adds support for manual addition of items to the recent items list, along with correctly detecting and getting the name of caged battle pets.