### PR TITLE
Fixed a bug during single cell currency updates.

### DIFF
--- a/modules/CurrencyFrame.lua
+++ b/modules/CurrencyFrame.lua
@@ -194,19 +194,24 @@ function mod:Update(event, currencyType, currencyQuantity)
 	if not self.widget or updating then return end
 	updating = true
 
-	-- Refresh only the affected cell.
+	local info
+	local updateCell
 	if currencyType ~= nil then
-		local info = GetCurrencyInfo(currencyType)
-		local cell = self.currencyToCell[info.name]
-		cell.text = cell.icon .. currencyQuantity
-		cell.fs:SetText(cell.text)
-		cell.frame:SetSize(
-			cell.fs:GetStringWidth(),
-			ceil(cell.fs:GetStringHeight())+3
+		info = GetCurrencyInfo(currencyType)
+		updateCell = self.currencyToCell[info.name]
+	end
+
+	-- Refresh only the affected cell.
+	if updateCell ~= nil then
+		updateCell.text = updateCell.icon .. BreakUpLargeNumbers(currencyQuantity)
+		updateCell.fs:SetText(updateCell.text)
+		updateCell.frame:SetSize(
+			updateCell.fs:GetStringWidth(),
+			ceil(updateCell.fs:GetStringHeight())+3
 		)
-		local column = cell.frame:GetParent()
-		if column:GetWidth() < cell.frame:GetWidth() then
-			column:SetWidth(cell.frame:GetWidth())
+		local column = updateCell.frame:GetParent()
+		if column:GetWidth() < updateCell.frame:GetWidth() then
+			column:SetWidth(updateCell.frame:GetWidth())
 		end
 		updating = false
 		return


### PR DESCRIPTION
This CL fixes #663 by having a failsafe in place if a currency frame is not found. This is a less-than-ideal fix, but we will revisit this at a later date to understand why this bug happens in the first place.