### PR TITLE
Reworked new item detection and change detection.

### DIFF
--- a/modules/NewItemTracking.lua
+++ b/modules/NewItemTracking.lua
@@ -62,6 +62,7 @@ function mod:OnInitialize()
 			glowScale = 1.5,
 			glowColor = { 0.3, 1, 0.3, 0.7 },
 			ignoreJunk = false,
+			highlightChangedItems = true,
 		},
 	})
 
@@ -134,7 +135,9 @@ function mod:UpdateModuleButton()
 end
 
 function mod:AddNewItem(event, link)
-	newItems[link] = true
+	if self.db.profile.highlightChangedItems then
+		newItems[link] = true
+	end
 end
 
 --------------------------------------------------------------------------------
@@ -215,6 +218,12 @@ function mod:GetOptions()
 			end,
 			width = 'double',
 		},
+		highlightChangedItems = {
+			name = L['Highlight items that have changed'],
+			type = 'toggle',
+			order = 50,
+			width = 'double'
+		}
 	}, addon:GetOptionHandler(self)
 end
 

--- a/modules/NewItemTracking.lua
+++ b/modules/NewItemTracking.lua
@@ -83,6 +83,7 @@ function mod:OnEnable()
 
 	self:RegisterMessage('AdiBags_UpdateButton', 'UpdateButton')
 	self:RegisterMessage('AdiBags_AddNewItem', 'AddNewItem')
+	self:RegisterMessage('AdiBags_ButtonProtoRelease', 'StopButtonGlow')
 	self:RegisterEvent('BAG_NEW_ITEMS_UPDATED')
 end
 
@@ -124,14 +125,18 @@ end
 
 function mod:UpdateButton(event, button)
 	if addon.BAG_IDS.BANK[button.bag] then
-		self:ShowLegacyGlow(button, false)
-		self:ShowBlizzardGlow(button, false)
+		self:StopButtonGlow(event, button)
 		return
 	end
 	local isNew = self:IsNew(button.bag, button.slot, button.itemLink)
 	self:ShowLegacyGlow(button, isNew and mod.db.profile.highlight == "legacy")
 	self:ShowBlizzardGlow(button, isNew and mod.db.profile.highlight == "blizzard")
 	self:UpdateModuleButton()
+end
+
+function mod:StopButtonGlow(event, button)
+	self:ShowLegacyGlow(button, false)
+	self:ShowBlizzardGlow(button, false)
 end
 
 function mod:UpdateModuleButton()

--- a/modules/NewItemTracking.lua
+++ b/modules/NewItemTracking.lua
@@ -62,7 +62,7 @@ function mod:OnInitialize()
 			glowScale = 1.5,
 			glowColor = { 0.3, 1, 0.3, 0.7 },
 			ignoreJunk = false,
-			highlightChangedItems = true,
+			highlightChangedItems = false,
 		},
 	})
 
@@ -123,7 +123,11 @@ function mod:OnBagFrameCreated(bag)
 end
 
 function mod:UpdateButton(event, button)
-	if addon.BAG_IDS.BANK[button.bag] then return end
+	if addon.BAG_IDS.BANK[button.bag] then
+		self:ShowLegacyGlow(button, false)
+		self:ShowBlizzardGlow(button, false)
+		return
+	end
 	local isNew = self:IsNew(button.bag, button.slot, button.itemLink)
 	self:ShowLegacyGlow(button, isNew and mod.db.profile.highlight == "legacy")
 	self:ShowBlizzardGlow(button, isNew and mod.db.profile.highlight == "blizzard")
@@ -232,6 +236,7 @@ end
 --------------------------------------------------------------------------------
 
 function mod:ShowBlizzardGlow(button, enable)
+	if not button.NewItemTexture then return end
 	if enable then
 		local _, _, _, quality = GetContainerItemInfo(button.bag, button.slot)
 		if quality and NEW_ITEM_ATLAS_BY_QUALITY[quality] then

--- a/widgets/ContainerFrame.lua
+++ b/widgets/ContainerFrame.lua
@@ -122,6 +122,8 @@ function containerProto:OnCreate(name, isBank, bagObject)
 	self.changed = {}
 	self.sameChanged = {}
 
+	self.itemGUIDtoItem = {}
+
 	local ids
 	for bagId in pairs(BAG_IDS[isBank and "BANK" or "BAGS"]) do
 		self.content[bagId] = { size = 0 }
@@ -603,7 +605,6 @@ end
 --------------------------------------------------------------------------------
 -- Bag content scanning
 --------------------------------------------------------------------------------
-local itemGUIDtoItem = {}
 
 function containerProto:UpdateContent(bag)
 	self:Debug('UpdateContent', bag)
@@ -668,7 +669,7 @@ function containerProto:UpdateContent(bag)
 				slotData.maxStack = maxStack or (link and 1 or 0)
 
 				if sameItem then
-					local context = itemGUIDtoItem[guid]
+					local context = self.itemGUIDtoItem[guid]
 					-- If this item is in the inventory, in the same slot, and has been indexed before,
 					-- i.e. not the first time the bag was opened, and the texture has changed, this means
 					-- the item has updated in some material way (i.e. wrapped in wrapping paper, unwrapped),
@@ -686,9 +687,9 @@ function containerProto:UpdateContent(bag)
 					-- Remove the old item, and add the new item to the
 					-- item index.
 					if prevGUID then
-						itemGUIDtoItem[prevGUID] = nil
+						self.itemGUIDtoItem[prevGUID] = nil
 					end
-					itemGUIDtoItem[guid] = slotData.itemLocation
+					self.itemGUIDtoItem[guid] = slotData.itemLocation
 				end
 			elseif slotData.count ~= count then
 				slotData.count = count

--- a/widgets/ItemButton.lua
+++ b/widgets/ItemButton.lua
@@ -115,6 +115,7 @@ function buttonProto:OnRelease()
 	self.texture = nil
 	self.bagFamily = nil
 	self.stack = nil
+	addon:SendMessage('AdiBags_ButtonProtoRelease', self)
 end
 
 function buttonProto:ToString()
@@ -469,6 +470,7 @@ function stackProto:OnRelease()
 	self:SetSection(nil)
 	self.key = nil
 	self.container = nil
+	addon:SendMessage('AdiBags_ButtonProtoRelease', self)
 	wipe(self.slots)
 end
 

--- a/widgets/ItemButton.lua
+++ b/widgets/ItemButton.lua
@@ -598,7 +598,14 @@ function stackProto:Update()
 	end
 end
 
-stackProto.FullUpdate = stackProto.Update
+function stackProto:FullUpdate()
+	if not self:CanUpdate() then return end
+	self:UpdateVisibleSlot()
+	self:UpdateCount()
+	if self.button then
+		self.button:FullUpdate()
+	end
+end
 
 function stackProto:UpdateCount()
 	local count = 0


### PR DESCRIPTION
This CL reworks the identifiers used to determine if items are the same when creating a bag view. Previously, AdiBags would use link parsing, while removing some fields, to determine if an item was the same and changed, or truly changed. With the addition of ItemLocationMixin, it is now possible to get an item's unique UID (guid), that ties an ID to that specific instance of an object.

Using this unique ID, AdiBags is now able to do much better new item tracking for situations where items may have changed in such a way where the Blizzard new item API did not trigger. An example of this is present wrapping: presents GUID's stay exactly the same, but the texture doesn't. We can now test if a GUID stays the same, and the texture changes, letting us take action, such as redispatching and updating the button.

This CL fixes #665 fully.