### PR TITLE
Section layout dupe

### DIFF
--- a/core/Utility.lua
+++ b/core/Utility.lua
@@ -342,6 +342,9 @@ end
 --------------------------------------------------------------------------------
 
 local function BuildSectionKey(name, category)
+	-- TODO(lobato): I think this is a bug, but I'm not sure. If the name is nil, then the category is used as the key,
+	-- which leads to duplicate keys.
+	assert(name ~= nil and name ~= "", "Tried to build a section key with no name. Report this to github.com/AdiAddons/AdiBags/issues please!")
 	if name ~= nil then
 		return strjoin('#', tostring(category or name), tostring(name))
 	end

--- a/widgets/ContainerFrame.lua
+++ b/widgets/ContainerFrame.lua
@@ -1042,11 +1042,15 @@ function containerProto:LayoutSections(maxHeight, columnWidth, minWidth, section
 	local columnPixelWidth = (ITEM_SIZE + ITEM_SPACING) * columnWidth - ITEM_SPACING + SECTION_SPACING
 	local getSection = addon.db.profile.compactLayout and FindFittingSection or GetNextSection
 
-	local numRows, x, y, rowHeight, maxSectionHeight, previous = 0, 0, 0, 0, 0
+	local numRows, x, y, rowHeight, maxSectionHeight, previous = 0, 0, 0, 0, 0, nil
 	while next(sections) do
 		local section
 		if x > 0 then
 			section = getSection(columnPixelWidth - x, sections)
+			-- Quick hack -- sometimes the same section is inserted twice for unknown reasons.
+			if section == previous then
+				goto continue
+			end
 			if section and previous then
 				section:SetPoint('TOPLEFT', previous, 'TOPRIGHT', SECTION_SPACING, 0)
 			else
@@ -1069,6 +1073,7 @@ function containerProto:LayoutSections(maxHeight, columnWidth, minWidth, section
 		previous = section
 		maxSectionHeight = max(maxSectionHeight, section:GetHeight())
 		rowHeight = max(rowHeight, section:GetHeight())
+		::continue::
 	end
 
 	local totalHeight = y + rowHeight

--- a/widgets/ContainerFrame.lua
+++ b/widgets/ContainerFrame.lua
@@ -1047,17 +1047,17 @@ function containerProto:LayoutSections(maxHeight, columnWidth, minWidth, section
 		local section
 		if x > 0 then
 			section = getSection(columnPixelWidth - x, sections)
-			-- Quick hack -- sometimes the same section is inserted twice for unknown reasons.
-			if section == previous then
-				goto continue
-			end
 			if section and previous then
-				section:SetPoint('TOPLEFT', previous, 'TOPRIGHT', SECTION_SPACING, 0)
+				-- Quick hack -- sometimes the same section is inserted twice for unknown reasons.
+				if section ~= previous then
+					section:SetPoint('TOPLEFT', previous, 'TOPRIGHT', SECTION_SPACING, 0)
+				end
 			else
 				x = 0
 				y = y + rowHeight + ROW_SPACING
 			end
 		end
+
 		if x == 0 then
 			section = tremove(sections, 1)
 			rowHeight = section:GetHeight()
@@ -1068,12 +1068,14 @@ function containerProto:LayoutSections(maxHeight, columnWidth, minWidth, section
 				section:SetPoint('TOPLEFT', rows[numRows-1], 'BOTTOMLEFT', 0, -ROW_SPACING)
 			end
 		end
-		x = x + section:GetWidth() + SECTION_SPACING
-		widths[numRows] = x - SECTION_SPACING
-		previous = section
-		maxSectionHeight = max(maxSectionHeight, section:GetHeight())
-		rowHeight = max(rowHeight, section:GetHeight())
-		::continue::
+
+		if section ~= previous then
+			x = x + section:GetWidth() + SECTION_SPACING
+			widths[numRows] = x - SECTION_SPACING
+			previous = section
+			maxSectionHeight = max(maxSectionHeight, section:GetHeight())
+			rowHeight = max(rowHeight, section:GetHeight())
+		end
 	end
 
 	local totalHeight = y + rowHeight


### PR DESCRIPTION
This CL works around a long standing bug where a section might be anchored against it self and cause an error in rare circumstances. This workaround doesn't fix the underlying bug, as it's difficult to reproduce, but does stop the frame from anchoring to it self.

This fixes #680.