### PR TITLE
Restore quest items functionality for WotLK

### DIFF
--- a/core/DefaultFilters.lua
+++ b/core/DefaultFilters.lua
@@ -195,7 +195,7 @@ function addon:SetupDefaultFilters()
 			if slotData.class == QUEST or slotData.subclass == QUEST then
 				return QUEST
 			else
-				if addon.isRetail then
+				if addon.isRetail or addon.isWrath then
 					local isQuestItem, questId = GetContainerItemQuestInfo(slotData.bag, slotData.slot)
 					return (questId or isQuestItem) and QUEST
 				else

--- a/widgets/ItemButton.lua
+++ b/widgets/ItemButton.lua
@@ -385,7 +385,7 @@ if addon.isRetail then
 end
 
 local function GetBorder(bag, slot, itemId, settings)
-	if addon.isRetail then
+	if addon.isRetail or addon.isWrath then
 		if settings.questIndicator then
 			local isQuestItem, questId, isActive = GetContainerItemQuestInfo(bag, slot)
 			if questId and not isActive then


### PR DESCRIPTION
The method `GetContainerItemQuestInfo` has been added back in WotLK, so we can retrieve quest items again and restore its original behavior. Currently, it only loads them on the Retail client.