### PR TITLE
Fix: Section SetPoint Layout Bug

### DIFF
--- a/widgets/ContainerFrame.lua
+++ b/widgets/ContainerFrame.lua
@@ -1042,6 +1042,9 @@ function containerProto:LayoutSections(maxHeight, columnWidth, minWidth, section
 	local columnPixelWidth = (ITEM_SIZE + ITEM_SPACING) * columnWidth - ITEM_SPACING + SECTION_SPACING
 	local getSection = addon.db.profile.compactLayout and FindFittingSection or GetNextSection
 
+	-- reset all sections so they aren't relative to each other
+	for key, section in pairs(sections) do section:ClearAllPoints() end
+	
 	local numRows, x, y, rowHeight, maxSectionHeight, previous = 0, 0, 0, 0, 0, nil
 	while next(sections) do
 		local section


### PR DESCRIPTION
This corrects the `SetPoint failed` issue, which can happen intermittently by resetting the `SetPoint` of each section at the beginning of the layout.

As best I can tell, this is caused by the sort order changing between layouts, which can cause occasionally cause any number of sections to form a circular dependency.

Addresses #551