### PR TITLE
Bug fix for BAG_UPDATE_DELAYED in Wrath

### DIFF
--- a/core/Core.lua
+++ b/core/Core.lua
@@ -370,6 +370,10 @@ end
 
 function addon:BAG_UPDATE(event, bag)
 	updatedBags[bag] = true
+	if addon.isWrath then
+		self:SendMessage('AdiBags_BagUpdated', updatedBags)
+		wipe(updatedBags)
+	end
 end
 
 function addon:BAG_UPDATE_DELAYED(event)


### PR DESCRIPTION
This CL fixes a bug in which sometimes in the Wrath client, the BAG_UPDATE_DELAYED event does not fire when looting. This is particularly noticeable when looting multiple items from in-game mail, which would completely break the addon's display of bag space.

I investigated using a bucket event instead of calling each pickup event individually, and while this worked, it led to some weird graphical artifacts in bag slots inbetween the update events, so I opted to update directly if the Wrath client is detect. This adds a slight bit more computation time when looting multiple items, but users shouldn't notice any difference.