### PR TITLE
Fix performance/lag when opening bag

### DIFF
--- a/widgets/ContainerFrame.lua
+++ b/widgets/ContainerFrame.lua
@@ -927,7 +927,7 @@ function containerProto:UpdateButtons()
 		return
 	end
 	self:Debug('UpdateButtons')
-
+	local added, removed, changed = self.added, self.removed, self.changed
 	self:SendMessage('AdiBags_PreContentUpdate', self, added, removed, changed)
 
 	for slotId in pairs(removed) do

--- a/widgets/ItemButton.lua
+++ b/widgets/ItemButton.lua
@@ -105,6 +105,7 @@ function buttonProto:OnAcquire(container, bag, slot)
 	self.bag = bag
 	self.slot = slot
 	self.stack = nil
+	self.dirty = true
 	self:SetParent(addon.itemParentFrames[bag])
 	--TODO(lobato): Add this when (if?) Blizzard fixes taint for bags
 	--self:SetBagID(bag)
@@ -123,6 +124,7 @@ function buttonProto:OnRelease()
 	self.texture = nil
 	self.bagFamily = nil
 	self.stack = nil
+	self.dirty = false
 	addon:SendMessage('AdiBags_ButtonProtoRelease', self)
 end
 
@@ -296,7 +298,7 @@ end
 --------------------------------------------------------------------------------
 
 function buttonProto:CanUpdate()
-	if not self:IsVisible() or addon.holdYourBreath then
+	if not self:IsVisible() or not self.dirty then
 		return false
 	end
 	return true
@@ -308,7 +310,8 @@ function buttonProto:FullUpdate()
 	self.itemLink = GetContainerItemLink(bag, slot)
 	self.hasItem = not not self.itemId
 	self.texture = addon:GetContainerItemTexture(bag, slot)
-
+	self.dirty = true
+	addon:Debug("Full Update", self.itemLink)
 	-- TODO(lobato): Test if this is still needed
 	if self.bag == REAGENTBAG_CONTAINER then
 		self.bagFamily = 2048
@@ -536,6 +539,7 @@ function stackProto:OnAcquire(container, key)
 	self.key = key
 	self.count = 0
 	self.dirtyCount = true
+	self.dirty = true
 	self:SetParent(container)
 end
 
@@ -544,6 +548,7 @@ function stackProto:OnRelease()
 	self:SetSection(nil)
 	self.key = nil
 	self.container = nil
+	self.dirty = false
 	addon:SendMessage('AdiBags_ButtonProtoRelease', self)
 	wipe(self.slots)
 end

--- a/widgets/ItemButton.lua
+++ b/widgets/ItemButton.lua
@@ -273,7 +273,7 @@ function buttonProto:OnShow()
 		self:RegisterEvent('INVENTORY_SEARCH_UPDATE', 'UpdateSearch')
 	end
 	self:RegisterEvent('UNIT_QUEST_LOG_CHANGED')
-	self:RegisterMessage('AdiBags_UpdateAllButtons', 'Update')
+	self:RegisterMessage('AdiBags_UpdateAllButtons', 'FullUpdate')
 	self:RegisterMessage('AdiBags_GlobalLockChanged', 'UpdateLock')
 	self:Update()
 end


### PR DESCRIPTION
This CL fixes performance when opening the bag beyond the first time. It functions by tracking the dirty state of item buttons, and only updating item buttons that need to be updated on bag open, instead of updating all items every time.

It also fixes a bug in which the entire bag was being rendered twice on every bag open, further degrading performance.