### PR TITLE
Experiments Framework

### DIFF
--- a/AdiBags.toc
+++ b/AdiBags.toc
@@ -45,6 +45,8 @@ libs\LibDataBroker-1.1\LibDataBroker-1.1.lua
 
 Localization.lua
 core\EventHandlers.lua
+core\Boot.lua
+core\Experiments.lua
 core\Fonts.lua
 core\Constants.lua
 core\Utility.lua

--- a/Annotations.lua
+++ b/Annotations.lua
@@ -408,5 +408,6 @@ function SetTooltipMoney(frame, money, type, prefixText, suffixText) end
 -- Define the main AdiBags addon object
 ---@class AdiBags-Proto
 ---@field ItemDatabase ItemDatabase
+---@field db AceDBObject-3.0
 
 ---@alias AdiBags AdiBags-Proto|AceAddon

--- a/config/Options.lua
+++ b/config/Options.lua
@@ -716,6 +716,13 @@ local function GetOptions()
 				args = moduleOptions,
 			},
 			profiles = profiles,
+			experiments = {
+				name = L['Experiments'],
+				desc = L['View your experiment groups and toggle participation.'],
+				type = 'group',
+				order = 9999,
+				args = {},
+			}
 		},
 		plugins = {}
 	}

--- a/config/Options.lua
+++ b/config/Options.lua
@@ -41,6 +41,9 @@ local LSM = LibStub('LibSharedMedia-3.0')
 
 local options
 
+local experiments = addon:GetModule("Experiments")
+---@cast experiments +Experiments
+
 --------------------------------------------------------------------------------
 -- Option handler prototype
 --------------------------------------------------------------------------------
@@ -721,7 +724,7 @@ local function GetOptions()
 				desc = L['View your experiment groups and toggle participation.'],
 				type = 'group',
 				order = 9999,
-				args = {},
+				args = experiments:GetOptions(),
 			}
 		},
 		plugins = {}

--- a/core/Boot.lua
+++ b/core/Boot.lua
@@ -1,0 +1,63 @@
+--[[
+AdiBags - Adirelle's bag addon.
+Copyright 2010-2021 Adirelle (adirelle@gmail.com)
+All rights reserved.
+
+This file is part of AdiBags.
+
+AdiBags is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+AdiBags is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with AdiBags.  If not, see <http://www.gnu.org/licenses/>.
+--]]
+
+-- This file handles the core loading of the addon before any other
+-- functions or embedding is done. Do not add any functions or logic
+-- to this file that is not related to the loading of the addon.
+
+local addonName, addon = ...
+
+LibStub('AceAddon-3.0'):NewAddon(addon, addonName, 'ABEvent-1.0', 'ABBucket-1.0', 'AceHook-3.0', 'AceConsole-3.0')
+--@debug@
+_G[addonName] = addon
+--@end-debug@
+
+addon:SetDefaultModuleState(false)
+
+--------------------------------------------------------------------------------
+-- Debug stuff
+--------------------------------------------------------------------------------
+
+--@alpha@
+---@type AdiDebug
+AdiDebug = AdiDebug
+
+if AdiDebug then
+	AdiDebug:Embed(addon, addonName)
+else
+--@end-alpha@
+	function addon.Debug() end
+--@alpha@
+end
+--@end-alpha@
+
+--------------------------------------------------------------------------------
+-- Module prototype
+--------------------------------------------------------------------------------
+
+local moduleProto = {
+	Debug = addon.Debug,
+	OpenOptions = function(self)
+		return addon:OpenOptions("modules", self.moduleName)
+	end,
+}
+addon.moduleProto = moduleProto
+addon:SetDefaultModulePrototype(moduleProto)

--- a/core/Constants.lua
+++ b/core/Constants.lua
@@ -218,6 +218,7 @@ addon.DEFAULT_SETTINGS = {
 			freeSpace = true,
 			notWhenTrading = 1,
 		},
+		experiments = {},
 		theme = {
 			currentTheme = "default",
 			backpack = {

--- a/core/Core.lua
+++ b/core/Core.lua
@@ -45,27 +45,9 @@ local type = _G.type
 local unpack = _G.unpack
 --GLOBALS>
 
-LibStub('AceAddon-3.0'):NewAddon(addon, addonName, 'ABEvent-1.0', 'ABBucket-1.0', 'AceHook-3.0', 'AceConsole-3.0')
---@debug@
-_G[addonName] = addon
---@end-debug@
-
 --------------------------------------------------------------------------------
--- Debug stuff
+-- Addon initialization and enabling
 --------------------------------------------------------------------------------
-
---@alpha@
----@type AdiDebug
-AdiDebug = AdiDebug
-
-if AdiDebug then
-	AdiDebug:Embed(addon, addonName)
-else
---@end-alpha@
-	function addon.Debug() end
---@alpha@
-end
---@end-alpha@
 
 --@debug@
 local function DebugTable(t, prevKey)
@@ -75,12 +57,6 @@ local function DebugTable(t, prevKey)
 	end
 end
 --@end-debug@
-
---------------------------------------------------------------------------------
--- Addon initialization and enabling
---------------------------------------------------------------------------------
-
-addon:SetDefaultModuleState(false)
 
 local bagKeys = {"backpack", "bank", "reagentBank"}
 function addon:OnInitialize()
@@ -352,19 +328,6 @@ do
 	end)
 
 end
-
---------------------------------------------------------------------------------
--- Module prototype
---------------------------------------------------------------------------------
-
-local moduleProto = {
-	Debug = addon.Debug,
-	OpenOptions = function(self)
-		return addon:OpenOptions("modules", self.moduleName)
-	end,
-}
-addon.moduleProto = moduleProto
-addon:SetDefaultModulePrototype(moduleProto)
 
 --------------------------------------------------------------------------------
 -- Event handlers

--- a/core/Experiments.lua
+++ b/core/Experiments.lua
@@ -1,0 +1,47 @@
+--[[
+AdiBags - Adirelle's bag addon.
+Copyright 2010-2023 Adirelle (adirelle@gmail.com)
+All rights reserved.
+
+This file is part of AdiBags.
+
+AdiBags is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+AdiBags is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with AdiBags.  If not, see <http://www.gnu.org/licenses/>.
+--]]
+
+
+local addonName, addon = ...
+
+---@cast addon +AdiBags
+
+local Experiments = addon:NewModule('Experiments')
+---@cast Experiments +Experiments
+
+---@diagnostic disable-next-line: duplicate-set-field
+function Experiments:OnInitialize()
+  self.experiments = {}
+end
+
+---@param exp Experiment
+function Experiments:CreateExperiment(exp)
+  assert(exp.Name, "Experiment must have a name")
+  assert(self.experiments[exp.Name] == nil, "Experiment with name " .. exp.Name .. " already exists")
+  self.experiments[exp.Name] = exp
+end
+
+---@class Experiment
+---@field Name string
+---@field Description string
+
+---@class Experiments
+---@field experiments table<string, Experiment>

--- a/core/Experiments.lua
+++ b/core/Experiments.lua
@@ -29,7 +29,7 @@ local Opts = LibStub('AceDBOptions-3.0')
 
 ---@diagnostic disable-next-line: duplicate-set-field
 function Experiments:OnInitialize()
-  self.experiments = addon.db.global.experiments or {}
+--  addon.db.global.experiments or {}
   self:CreateAllExperiments()
 end
 
@@ -40,12 +40,12 @@ function Experiments:CreateExperiment(exp)
   assert(exp.Percent ~= nil and exp.Percent >= 0 and exp.Percent <= 100, "Experiment percent must be between 0 and 100")
 
   -- Don't create the experiment if it already exists with the same percentage, as this was loaded from disk.
-  if self.experiments[exp.Name] ~= nil and self.experiments[exp.Name].Percent == exp.Percent then
+  if addon.db.profile.experiments[exp.Name] ~= nil and addon.db.profile.experiments[exp.Name].Percent == exp.Percent then
     return
   end
 
   -- Don't recalculate already enabled experiements, recalculation can only add users to the cohort, not remove them.
-  if self.experiments[exp.Name] ~= nil and self.experiments[exp.Name].Enabled then
+  if addon.db.profile.experiments[exp.Name] ~= nil and addon.db.profile.experiments[exp.Name].Enabled then
     return
   end
 
@@ -56,15 +56,15 @@ function Experiments:CreateExperiment(exp)
     exp.Enabled = false
   end
 
-  self.experiments[exp.Name] = exp
+  addon.db.profile.experiments[exp.Name] = exp
 end
 
 -- Enabled returns whether or not any experiment is enabled for this user.
 ---@param name string
 ---@return boolean
 function Experiments:Enabled(name)
-  assert(self.experiments[name] ~= nil, "Experiment with name " .. name .. " does not exist")
-  return self.experiments[name].Enabled
+  assert(addon.db.profile.experiments[name] ~= nil, "Experiment with name " .. name .. " does not exist")
+  return addon.db.profile.experiments[name].Enabled
 end
 
 function Experiments:CreateAllExperiments()
@@ -77,16 +77,16 @@ end
 
 function Experiments:GetOptions()
   local options = {}
-  for name, experiment in pairs(self.experiments) do
+  for name, experiment in pairs(addon.db.profile.experiments) do
     options[name] = {
       type = "toggle",
       name = experiment.Name,
       desc = experiment.Description,
       get = function()
-        return experiment.Enabled
+        return addon.db.profile.experiments[name].Enabled
       end,
       set = function(_, value)
-        experiment.Enabled = value
+        addon.db.profile.experiments[name].Enabled = value
       end,
     }
   end


### PR DESCRIPTION
This CL adds a few Experiments framework for new feature development and feature flags. Experiments can be defined globally along with a percentile of users that will be opted into this new feature. The enabled state of the feature can then be used to guard new features to allow for a slower rollout, combined with the ability for users to self-rollback via the new options window for experiments.