### PR TITLE
Fix CURSOR_UPDATE error

### DIFF
--- a/AdiBags_Vanilla.toc
+++ b/AdiBags_Vanilla.toc
@@ -17,7 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with AdiBags.  If not, see <http://www.gnu.org/licenses/>.
 
-## Interface: 11403
+## Interface: 11404
 
 ## Title: AdiBags
 ## Notes: Adirelle's bag addon.

--- a/modules/FilterOverride.lua
+++ b/modules/FilterOverride.lua
@@ -115,7 +115,7 @@ end
 
 function mod:OnEnable()
 	self:UpdateOptions()
-        self:RegisterEvent('CURSOR_CHANGED')
+	self:RegisterEvent('CURSOR_CHANGED')
 	addon.RegisterSectionHeaderScript(self, 'OnTooltipUpdate', 'OnTooltipUpdateSectionHeader')
 	addon.RegisterSectionHeaderScript(self, 'OnClick', 'OnClickSectionHeader')
 	self:CURSOR_CHANGED()

--- a/modules/FilterOverride.lua
+++ b/modules/FilterOverride.lua
@@ -115,11 +115,7 @@ end
 
 function mod:OnEnable()
 	self:UpdateOptions()
-	if addon.isRetail or addon.isWrath then
-		self:RegisterEvent('CURSOR_CHANGED')
-	else
-		self:RegisterEvent('CURSOR_UPDATE', 'CURSOR_CHANGED')
-	end
+        self:RegisterEvent('CURSOR_CHANGED')
 	addon.RegisterSectionHeaderScript(self, 'OnTooltipUpdate', 'OnTooltipUpdateSectionHeader')
 	addon.RegisterSectionHeaderScript(self, 'OnClick', 'OnClickSectionHeader')
 	self:CURSOR_CHANGED()


### PR DESCRIPTION
Fixes #983 #985 and updates toc to 1.14.4

CURSOR_UPDATE is no longer valid event, this updates it to current api