### PR TITLE
Fix for Season of Discovery custom max levels per phase

### DIFF
--- a/modules/ItemLevel.lua
+++ b/modules/ItemLevel.lua
@@ -350,6 +350,9 @@ do
 		}
 	else
 		maxLevelRanges = {
+            [25]  = {  66,  92 }, -- Classic Season of Disocvery Phase 1
+            [40]  = {  66,  92 }, -- Classic Season of Disocvery Phase 2
+            [50]  = {  66,  92 }, -- Classic Season of Disocvery Phase 3
 			[60]  = {  66,  92 },
 			[70]  = { 100, 164 },
 			[80]  = { 187, 284 },


### PR DESCRIPTION
_G.MAX_PLAYER_LEVEL is set to the max level for the phase after a /reloadui in game. When logging in initially it is 60 but after reloading or changing zones the change causes a LUA error every time the bags are opened.