### PR TITLE
Fixed non-equipment items acting as equipment after 10.2.6 WoW patch.

### DIFF
--- a/core/DefaultFilters.lua
+++ b/core/DefaultFilters.lua
@@ -248,7 +248,7 @@ function addon:SetupDefaultFilters()
 
 		local equipmentFilter = addon:RegisterFilter('Equipment', 60, function(self, slotData)
 			local equipSlot = slotData.equipSlot
-			if equipSlot and equipSlot ~= "" then
+			if equipSlot and equipSlot ~= "" and equipSlot ~= "INVTYPE_NON_EQUIP_IGNORE" then
 				local rule = self.db.profile.dispatchRule
 				local category
 				if rule == 'category' then

--- a/modules/ItemLevel.lua
+++ b/modules/ItemLevel.lua
@@ -163,7 +163,7 @@ function mod:UpdateButton_Retail(event, button)
 			level = item and item:GetCurrentItemLevel() or 0
 			if level >= settings.minLevel
 				and (quality ~= ITEM_QUALITY_POOR or not settings.ignoreJunk)
-				and (loc ~= "" or not settings.equippableOnly)
+				and (loc ~= "" and loc ~= "INVTYPE_NON_EQUIP_IGNORE" or not settings.equippableOnly)
 				and (quality ~= ITEM_QUALITY_HEIRLOOM or not settings.ignoreHeirloom)
 				and colorSchemes[settings.colorScheme] ~= nil
 			then


### PR DESCRIPTION
This fixes issue #1004, also contains the fix from PR #1005.